### PR TITLE
Break notifications

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -70,3 +70,17 @@ immediately if there is a ping.
 
 To prevent spam or misuse, it is also recommended that the **"Allow non-entrant 
 chat"** race setting is disabled when conducting a race using FPA.
+
+## !breaks
+
+Usable by: anyone
+
+Enable or disable reminders for regular breaks during the race. No notifications
+are sent by default, they can be configured by specifying the duration of the
+breaks and their interval, for example with `!breaks 5m every 2h30m`. They can
+be toggled off again with `!breaks off`.
+
+The bot will post notifications 5 minutes ahead of, as well as at the start and
+end of each break. It is recommended to enable desktop notifications using the
+bell icon in racetime.gg chat when using breaks. This way your browser will
+notify you for these reminders.

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version='1.0.0',
     install_requires=[
         'racetime_bot>=1.5.0,<2.0',
+        'isodate>=0.6.1,<0.7',
     ],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
This adds a `!breaks` command to the bot, allowing runners to get automatic reminders if they wish to take regular breaks during the race.

Example syntax: `!breaks 5m every 2h30` or `!breaks off`. The duration parser is fairly lenient, allowing durations with or without spaces (`2h 30m` or `2h30m`), omitting units with reasonable defaults (the next smaller unit after the previous one, e.g. `2h30` = `2h30m`, or minutes for the duration or hours for the interval, e.g. `!breaks 5 every 2` = `!breaks 5m every 2h`), and using `:` as a separator (e.g. `!breaks 7:30 every 2:30` = `!breaks 7m30s every 2h30m`). Typing `!breaks` without any arguments will show the currently configured breaks and example syntax for changing it.

This feature was originally implemented in [my fork](https://github.com/fenhl/rslbot) since breaks were essentially exclusive to the Random Settings League. Now that the ongoing Mixed Pools tournament has optional breaks as well, it makes sense to upstream the feature.

Caveat: For RSLBot, the break notifications seem to stop working during the race in rare cases. It might be caused by network issues, not sure, but the command may not be 100% reliable.