### PR TITLE
Ignore races handled by Mido

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -15,11 +15,11 @@ class RandoHandler(RaceHandler):
         self.zsr = zsr
 
     def should_stop(self):
+        goal_name = self.data.get('goal', {}).get('name')
+        goal_is_custom = self.data.get('goal', {}).get('custom', False)
         return (
-            (
-                self.data.get('goal', {}).get('name') == 'Random settings league'
-                and not self.data.get('goal', {}).get('custom', False)
-            )
+            (goal_name == 'Random settings league' and not goal_is_custom) # handled by https://github.com/fenhl/rslbot
+            or (goal_name == '3rd Multiworld Tournament' and goal_is_custom) # handled by https://github.com/midoshouse/midos.house
             or super().should_stop()
         )
 


### PR DESCRIPTION
Mido, the racetime.gg bot for [Mido's House](https://midos.house/), will open race rooms with the custom goal “3rd Multiworld Tournament”. In those rooms, Mido will handle everything normally handled by RandoBot, so this PR makes sure RandoBot won't also appear in them. In case someone manually opens a race with this exact custom goal, I plan to have Mido post an error message, or maybe even offer to roll a seed with the tournament settings.