### PR TITLE
Fix seeddev rolling failling for presets not on main

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -300,10 +300,12 @@ class RandoHandler(RaceHandler):
         """
         Generate a seed and send it to the race room.
         """
-        if preset not in self.zsr.presets:
+        
+        if (dev and preset not in self.zsr.presets_dev) or (not dev and preset not in self.zsr.presets):
+            res_cmd = '!presetsdev' if dev else '!presets'
             await self.send_message(
                 'Sorry %(reply_to)s, I don\'t recognise that preset. Use '
-                '!presets to see what is available.'
+                '%(res_cmd)s to see what is available.'
                 % {'reply_to': reply_to or 'friend'}
             )
             return


### PR DESCRIPTION
The seed roll function only checked the main presets list even for dev seeds. New presets only on dev are rejected for that reason. This should fix the issue and also spit out the correct command in response.

Ultra late, so sorry for mistakes.