### PR TITLE
Check Mido's House API for custom goals to ignore

### DIFF
--- a/randobot/bot.py
+++ b/randobot/bot.py
@@ -1,8 +1,7 @@
-import gql
-import gql.transport.aiohttp
 from racetime_bot import Bot
 
 from .handler import RandoHandler
+from .midos_house import MidosHouse
 from .zsr import ZSR
 
 
@@ -13,7 +12,7 @@ class RandoBot(Bot):
     def __init__(self, ootr_api_key, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.zsr = ZSR(ootr_api_key)
-        self.midos_house = gql.Client(transport=gql.transport.aiohttp.AIOHTTPTransport(url='https://midos.house/api/v1/graphql'))
+        self.midos_house = MidosHouse()
 
     def get_handler_class(self):
         return RandoHandler

--- a/randobot/bot.py
+++ b/randobot/bot.py
@@ -1,3 +1,5 @@
+import gql
+import gql.transport.aiohttp
 from racetime_bot import Bot
 
 from .handler import RandoHandler
@@ -11,6 +13,7 @@ class RandoBot(Bot):
     def __init__(self, ootr_api_key, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.zsr = ZSR(ootr_api_key)
+        self.midos_house = gql.Client(transport=gql.transport.aiohttp.AIOHTTPTransport(url='https://midos.house/api/v1/graphql'))
 
     def get_handler_class(self):
         return RandoHandler
@@ -19,4 +22,5 @@ class RandoBot(Bot):
         return {
             **super().get_handler_kwargs(*args, **kwargs),
             'zsr': self.zsr,
+            'midos_house': self.midos_house,
         }

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -3,7 +3,6 @@ import contextlib
 import datetime
 import json
 import re
-import gql
 import isodate
 from racetime_bot import RaceHandler, monitor_cmd, can_moderate, can_monitor
 
@@ -76,17 +75,11 @@ class RandoHandler(RaceHandler):
         goal_name = self.data.get('goal', {}).get('name')
         goal_is_custom = self.data.get('goal', {}).get('custom', False)
         if goal_is_custom:
+            if self.midos_house.handles_custom_goal(goal_name):
+                return True # handled by https://github.com/midoshouse/midos.house
+        else:
             if goal_name == 'Random settings league':
                 return True # handled by https://github.com/fenhl/rslbot
-        else:
-            with contextlib.suppress(Exception): # if anything goes wrong, assume Mido's House is down and we should handle the room
-                query = gql.gql("""
-                    query {
-                        goalNames
-                    }
-                """)
-                if goal_name in self.midos_house.execute(query)['goalNames']:
-                    return True # handled by https://github.com/midoshouse/midos.house
         return super().should_stop()
 
     async def begin(self):

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -1,5 +1,4 @@
 from asyncio import create_task, gather, sleep
-import contextlib
 import datetime
 import json
 import re

--- a/randobot/midos_house.py
+++ b/randobot/midos_house.py
@@ -7,19 +7,21 @@ class MidosHouse:
     def __init__(self):
         self.client = gql.Client(transport=gql.transport.aiohttp.AIOHTTPTransport(url='https://midos.house/api/v1/graphql'))
         self.cache = None
-        self.cache_last_updated = None
+        self.cache_expires_at = time.monotonic()
 
     async def handles_custom_goal(self, goal_name):
-        if self.cache is None or time.monotonic() > self.cache_last_updated + 60 * 60 * 24:
+        if time.monotonic() > self.cache_expires_at:
             try:
                 query = gql.gql("""
                     query {
                         goalNames
                     }
                 """)
-                self.cache_last_updated = time.monotonic()
+                self.cache_expires_at = time.monotonic() + 60 * 60 * 24
                 self.cache = self.client.execute(query)['goalNames']
             except gql.transport.exceptions.TransportError: # if anything goes wrong, assume Mido's House is down and we should handle the room
+                self.cache_expires_at = time.monotonic() + 60
                 self.cache = None
-                return False
+        if self.cache is None:
+            return False
         return goal_name in self.cache

--- a/randobot/midos_house.py
+++ b/randobot/midos_house.py
@@ -1,0 +1,25 @@
+import time
+
+import gql
+import gql.transport.aiohttp
+
+class MidosHouse:
+    def __init__(self):
+        self.client = gql.Client(transport=gql.transport.aiohttp.AIOHTTPTransport(url='https://midos.house/api/v1/graphql'))
+        self.cache = None
+        self.cache_last_updated = None
+
+    async def handles_custom_goal(self, goal_name):
+        if self.cache is None or time.monotonic() > self.cache_last_updated + 60 * 60 * 24:
+            try:
+                query = gql.gql("""
+                    query {
+                        goalNames
+                    }
+                """)
+                self.cache_last_updated = time.monotonic()
+                self.cache = self.client.execute(query)['goalNames']
+            except gql.transport.exceptions.TransportError: # if anything goes wrong, assume Mido's House is down and we should handle the room
+                self.cache = None
+                return False
+        return goal_name in self.cache

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     version='1.0.0',
     install_requires=[
         'racetime_bot>=1.5.0,<2.0',
-        'gql>=3.4.0,<4.0',
+        'gql[aiohttp]>=3.4.0,<4.0',
         'isodate>=0.6.1,<0.7',
     ],
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version='1.0.0',
     install_requires=[
         'racetime_bot>=1.5.0,<2.0',
+        'gql>=3.4.0,<4.0',
         'isodate>=0.6.1,<0.7',
     ],
     packages=find_packages(),


### PR DESCRIPTION
Instead of hardcoding goal names to ignore since they're handled by Mido (the racetime.gg bot for [Mido's House](https://midos.house/)), this PR has RandoBot check the goal name against a list from the Mido's House [GraphQL](https://graphql.org/) API. This API endpoint does not requires any authentication, so it should work as-is. If anything goes wrong during the API call, RandoBot assumes Mido's House is down and defaults to handling the room itself.

I'm not too familiar with setup.py dependency handling, so I'm not sure whether the dependency will work correctly — I had to install it as `pip install gql[aiohttp]` for it to work.