### PR TITLE
Don't handle races on the Triforce Blitz goal

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -75,10 +75,12 @@ class RandoHandler(RaceHandler):
         goal_is_custom = self.data.get('goal', {}).get('custom', False)
         if goal_is_custom:
             if self.midos_house.handles_custom_goal(goal_name):
-                return True # handled by https://github.com/midoshouse/midos.house
+                return True # handled by Mido (https://github.com/midoshouse/midos.house)
         else:
             if goal_name == 'Random settings league':
-                return True # handled by https://github.com/fenhl/rslbot
+                return True # handled by RSLBot (https://github.com/midoshouse/midos.house)
+            elif goal_name == 'Triforce Blitz':
+                return True # handled by Mido (https://github.com/midoshouse/midos.house)
         return super().should_stop()
 
     async def begin(self):


### PR DESCRIPTION
The Triforce Blitz S2 tournament will be scheduled via Mido's House and we're planning to have Mido automatically open race rooms like for Multiworld S3. Mido will also handle TFB rooms not opened by himself and provide a `!seed` command that works for TFB. Since Triforce Blitz is not a custom goal, this needs to be handled here.

Supersedes #9.