### PR TITLE
Fix bug with pick order

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -526,8 +526,7 @@ class RandoHandler(RaceHandler):
                     return
                 if draft.get('pick_count') == 2:
                     draft.update({
-                        'status': 'minor_pick',
-                        'current_selector': racer[1].get('name')
+                        'status': 'minor_pick'
                     })
                     await self.send_message(
                         f"{draft.get('current_selector')}, modify a minor setting with !pick <setting> <value>."


### PR DESCRIPTION
This fixes a bug with the pick order. Picks should be ordered as following:

ABABBA

Previously, the racer with the lowest racetime.gg points/qualifier placement would always pick the first minor setting.