### PR TITLE
Make Randobot's drafts a bit more user friendly

### DIFF
--- a/randobot/friendly_names.py
+++ b/randobot/friendly_names.py
@@ -1,0 +1,139 @@
+class FriendlyNames:
+    draftables = {
+        "bridge": {
+            "__setting": "Rainbow Bridge",
+            "open": "Open bridge, 6 med GCBK"
+        },
+        "deku": {
+            "__setting":"Kokiri Forest",
+            "open": "Open Forest",
+        },
+        "interiors": {
+            "__setting":"Indoor Entrance Randomizer",
+            "on": "Enabled",
+        },
+        "dungeons": {
+            "__setting":"Dungeon Entrance Randomizer",
+            "on": "Simple (no Ganon's Castle)",
+        },
+        "grottos": {
+            "__setting":"Grotto Entrance Randomizer",
+            "on": "Enabled",
+        },
+        "shops": {
+            "__setting":"Shopsanity",
+            "on": "4 items, random prices",
+        },
+        "ow_tokens": {
+            "__setting":"Overworld Tokens",
+            "on": "Shuffled",
+        },
+        "dungeon_tokens": {
+            "__setting":"Dungeon Tokens",
+            "on": "Shuffled",
+        },
+        "scrubs": {
+            "__setting":"Scrub shuffle",
+            "on": "Enabled, affordable prices",
+        },
+        "keys": {
+            "__setting":"Small Keys",
+            "keysy": "Keysy (dungeon small keys and boss keys removed)",
+            "anywhere": "Keyrings anywhere (include Boss Keys)",
+        },
+        "required_only": {
+            "__setting":"Reachable Locations",
+            "on": "Required Only (aka Beatable Only)",
+        },
+        "fountain": {
+            "__setting":"Zora's Fountain",
+            "open": "Open Fountain",
+        },
+        "cows": {
+            "__setting":"Cowsanity",
+            "on": "Enabled",
+        },
+        "gerudo_card": {
+            "__setting":"Shuffle Gerudo Card",
+            "on": "Enabled",
+        },
+        "trials": {
+            "__setting":"Ganon's Trials",
+            "on": "3 Trials",
+        },
+        "door_of_time": {
+            "__setting":"Door of Time",
+            "closed": "Closed",
+        },
+        "starting_age": {
+            "__setting":"Starting Age",
+            "child": "Child",
+            "adult": "Adult",
+        },
+        "random_spawns": {
+            "__setting":"Random Spawns",
+            "on": "Enabled",
+        },
+        "consumables": {
+            "__setting":"Start with Consumables",
+            "none": "Disabled",
+        },
+        "rupees": {
+            "__setting":"Start with max Rupees",
+            "startwith": "Enabled",
+        },
+        "cuccos": {
+            "__setting":"Anju's Chickens",
+            "1": "1 Cucco",
+        },
+        "free_scarecrow": {
+            "__setting":"Free Scarecrow",
+            "on": "Enabled",
+        },
+        "camc": {
+            "__setting":"Chest Appearance Matches Contents",
+            "off": "Disabled",
+        },
+        "mask_quest": {
+            "__setting":"Mask Quest",
+            "complete": "Complete, fast Bunny Hood disabled",
+        },
+        "blue_fire_arrows": {
+            "__setting":"Blue Fire Arrows",
+            "on": "Enabled",
+        },
+        "owl_warps": {
+            "__setting":"Random Owl Warps",
+            "random": "Enabled",
+        },
+        "song_warps": {
+            "__setting":"Random Warp Song Destinations",
+            "random": "Enabled",
+        },
+        "shuffle_beans": {
+            "__setting":"Shuffle Magic Beans",
+            "on": "Enabled",
+        },
+        "expensive_merchants": {
+            "__setting":"Shuffle Expensive Merchants",
+            "on": "Enabled",
+        },
+        "beans_planted": {
+            "__setting":"Pre-planted Magic Beans",
+            "on": "Enabled",
+        },
+        "bombchus_in_logic": {
+            "__setting":"Bombchu Bag and Drops",
+            "on": "Enabled (Bombchus in logic)",
+        },
+    }
+
+    def __init__(self):
+        pass
+
+    def setting(self, setting):
+        return self.draftables.get(setting).get("__setting") if setting in self.draftables else setting.capitalize()
+
+    def option(self, setting, option):
+        return self.draftables.get(setting).get(option) \
+            if setting in self.draftables and option in self.draftables[setting] else option.capitalize()

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -390,7 +390,7 @@ class RandoHandler(RaceHandler):
             actions=[
                 msg_actions.Action(
                     label='Ban a setting',
-                    help_text='Pick a setting to ban from the list',
+                    help_text='Pick a setting to ban from the list.',
                     message='!ban ${setting}',
                     submit='Ban setting',
                     survey=msg_actions.Survey(
@@ -403,7 +403,7 @@ class RandoHandler(RaceHandler):
                 ),
                 msg_actions.Action(
                     label='Skip',
-                    help_text='Skip your ban phase and yield to the other player',
+                    help_text='Skip your ban phase and yield to the other player.',
                     message='!skip',
                 ),
             ]
@@ -637,10 +637,11 @@ class RandoHandler(RaceHandler):
                 await self.draft_pick_major_setting(reply_to, setting, option)
             elif len(args) == 2:
                 await self.draft_pick_major_setting(reply_to, args[0], args[1])
-            # Handle invalid format
-            await self.send_message(
-                'Invalid use of !pick command. Use !pick <setting> <option>.'
-            )
+            else:
+                # Handle invalid format
+                await self.send_message(
+                    'Invalid use of !pick command. Use !pick <setting> <option>.'
+                )
         elif reply_to == draft.get('current_selector') and draft.get('status') == 'minor_pick':
             # Handle selecting setting from different pool.
             if len(args) == 2 and args[0] in major_pool.keys():
@@ -654,10 +655,11 @@ class RandoHandler(RaceHandler):
                 await self.draft_pick_minor_setting(reply_to, setting, option)
             elif len(args) == 2:
                 await self.draft_pick_minor_setting(reply_to, args[0], args[1])
-            # Handle invalid format
-            await self.send_message(
-                'Invalid use of !pick command. Use !pick <setting> <option>.'
-            )
+            else:
+                # Handle invalid format
+                await self.send_message(
+                    'Invalid use of !pick command. Use !pick <setting> <option>.'
+                )
 
     async def ex_settings(self, args, message):
         """


### PR DESCRIPTION
This PR will..

* Add the option to `!pick random` - let randobot pick a major or minor setting for the user.
* Add survey buttons / select fields to randobot's drafting process.
* Use friendlier names for settings, in line with what the Discord draft bot does.

Here's how that looks in practice:
![First part of draft, guiding users through the process with buttons and surveys](https://github.com/deains/ootr-randobot/assets/112709/f2150d14-8689-45d5-af8a-50e1e6adab88)
![Second part of draft, including pinned settings that use user-friendly names](https://github.com/deains/ootr-randobot/assets/112709/5d5e79a4-c97f-45a8-8ad9-720044f35974)
![Detail screenshot of a survey form to pick a setting](https://github.com/deains/ootr-randobot/assets/112709/c5462d9e-872f-4db3-a461-f26080929bd2)
