### PR TITLE
Fix bug caused by adding conditional tricks

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -1001,8 +1001,8 @@ class RandoHandler(RaceHandler):
         preset.update(data)
 
         # If dungeon er is on, add logic_dc_scarecrow_gs to trick list
-        for key, value in data.items():
-            if key == 'shuffle_dungeon_entrances' and value == 'simple':
+        for setting in data.keys():
+            if setting == 'shuffle_dungeon_entrances' and data[setting] == 'simple':
                 preset['allowed_tricks'].append('logic_dc_scarecrow_gs')
 
         return preset


### PR DESCRIPTION
![image](https://github.com/deains/ootr-randobot/assets/82658083/d139cd68-c140-4f11-87fe-2ec9b4fa1e88)

Originally, the bot would append this specific trick regardless of whether dungeon er was on or not which is not intended behavior.

This change ensures that the trick will only be added if dungeon_er is set to 'simple'