### PR TITLE
Configurable Draft Races

### DIFF
--- a/randobot/draft.py
+++ b/randobot/draft.py
@@ -29,13 +29,12 @@ class PlayerDraft(Handler):
     """
     Class for handling draft-style races
     """
-    def __init__(self, entrants, settings_pool, config, qual_data):
+    def __init__(self, settings_pool, args):
         super().__init__(settings_pool)
-        self.race_type, *self.draftees, self.is_tournament_race, self.bans_each, self.major_picks_each, self.minor_picks_each = config
-        self.player_bans = {}
-        self.player_picks = {}
+        self.race_type, *self.draftees, self.is_tournament_race, self.bans_each, self.major_picks_each, self.minor_picks_each = args
+        self.player_bans = []
+        self.player_picks = []
         self.current_selector = None
-        self.determine_higher_seed(entrants, qual_data)
 
     def determine_higher_seed(self, entrants, qual_data):
         _draftees = []
@@ -44,43 +43,74 @@ class PlayerDraft(Handler):
             for draftee in self.draftees:
                 for racer in qual_data:
                     if draftee == racer['name'].lower():
-                        _draftees.append({'name': draftee, 'place': racer['place']})
+                        _draftees.append({'name': draftee.capitalize(), 'place': racer['place']})
             self.draftees = sorted(_draftees, key=lambda draftee: draftee['place'])
         # Sort by racetime.gg points
         else:
             for draftee in self.draftees:
                 for entrant in entrants:
                     if draftee == entrant['user']['name'].lower():
-                        _draftees.append({'name': draftee, 'score': entrant['score'] if entrant.get('score') else 0})
+                        _draftees.append({'name': draftee.capitalize(), 'score': entrant['score'] if entrant.get('score') else 0})
             self.draftees = sorted(_draftees, key=lambda draftee: draftee['score'], reverse=True)
 
-    def assign_draft_order(self, message, config):
+    def assign_draft_order(self, args, message):
         if len(self.draftees) == 2:
             user = message.get('user', {}).get('name')
             if user == self.draftees[0]['name']:
-                if message.get('message_plain', '') == '!first':
+                if message.get('message_plain', '').startswith('!first'):
                     self.current_selector = self.draftees[0]['name']
-                elif message.get('message_plain', '') == '!second':
+                elif message.get('message_plain', '').startswith('!second'):
                     self.current_selector = self.draftees[1]['name']
+
+    def skip_ban(self, message):
+        user = message.get('user', {}).get('name')
+        _draftees = list(enumerate(self.draftees))
+        for index, draftee in _draftees:
+            if user == draftee['name'] and user == self.current_selector:
+                self.player_bans.append({
+                    user: 'Skipped'
+                })
+                self.current_selector = self.draftees[index + 1 if index < len(_draftees) - 1 else 0]['name']
+                if len(self.player_bans) >= int(self.bans_each) * len(self.draftees):
+                    return
+                return True
+
+    def ban_setting(self, args, message):
+        user = message.get('user', {}).get('name')
+        pool = self.settings_pool['major'] | self.settings_pool['minor']
+        _draftees = list(enumerate(self.draftees))
+        for index, draftee in _draftees:
+            if user == draftee['name'] and user == self.current_selector:
+                if len(args) == 1 and args[0] in pool:
+                    self.player_bans.append({
+                        user: pool[args[0]]['_setting']
+                    })
+                    pool.pop(args[0])
+                    self.current_selector = self.draftees[index + 1 if index < len(_draftees) - 1 else 0]['name']
+                    if len(self.player_bans) >= int(self.bans_each) * len(self.draftees):
+                        return
+                    return True
             return
-        self.draftees = config
-        self.current_selector = self.draftees[0]
 
-    def skip_ban(self):
+    def pick_setting(self, args, message):
         pass
 
-    def ban_setting(self):
-        pass
-
-    def pick_setting(self):
-        pass
-
-    def send_available_settings(self):
-        pool = self.settings_pool
-        return {
-            setting: f"{pool[setting]['__setting']}: {pool[setting]['options'][pool[setting]['default']]['name']}"
-            for setting in pool
-        }
+    def send_available_settings(self, state):
+        if state == 'player_bans':
+            pool = self.settings_pool['major'] | self.settings_pool['minor']
+            return {
+                f"{setting}": f"{pool[setting]['_setting']}: {pool[setting]['options'][pool[setting]['default']]['name']}"
+                for setting in pool
+            }
+        elif state == 'player_picks':
+            if len(self.player_picks) < int(self.major_picks_each):
+                pool = self.settings_pool['major']
+            else:
+                pool = self.settings_pool['minor']
+            return {
+                f"{setting} {option}": f"{pool[setting]['_setting']}: {pool[setting]['options'][option]['name']}"
+                for setting in pool for option in pool[setting]['options'] if option != pool[setting]['default']
+            }
 
 class RandomDraft(Handler):
     """
@@ -96,10 +126,8 @@ class RandomDraft(Handler):
         _num_minor_settings = int(self.num_minor_settings)
         count = 0
         while count < _num_major_settings + _num_minor_settings:
-            # Select from major pool
             if count < _num_major_settings:
                 pool = self.settings_pool['major']
-            # Select from minor pool
             else:
                 pool = self.settings_pool['minor']
             setting = random.choice(list(pool))
@@ -111,7 +139,7 @@ class RandomDraft(Handler):
                     key: value
                 })
             self.selected_settings.update({
-                pool[setting]['__setting']: pool[setting]['options'][option]['name']
+                pool[setting]['_setting']: pool[setting]['options'][option]['name']
             })
             pool.pop(setting)
             count += 1

--- a/randobot/draft.py
+++ b/randobot/draft.py
@@ -47,11 +47,10 @@ class PlayerDraft(Handler):
         _draftees = []
         # Sort by qualifier placement
         if self.is_tournament_race:
-            placements = qual_data
             for draftee in self.draftees:
-                for place in placements:
-                    if draftee == place['name'].lower():
-                        _draftees.append({'name': draftee, 'place': place['place']})
+                for racer in qual_data:
+                    if draftee == racer['name'].lower():
+                        _draftees.append({'name': draftee, 'place': racer['place']})
             self.draftees = sorted(_draftees, key=lambda draftee: draftee['place'])
         # Sort by racetime.gg points
         else:

--- a/randobot/draft.py
+++ b/randobot/draft.py
@@ -1,0 +1,109 @@
+import random
+from copy import deepcopy
+
+class Handler:
+    """
+    Base class for handling draft data
+    """
+    def __init__(self, settings_pool):
+        self.major_settings_pool = settings_pool['major']
+        self.minor_settings_pool = settings_pool['minor']
+        self.generator_data = {}
+
+    def handle_conditional_settings(self):
+        settings = self.zsr.presets.get('s7').get('settings')
+        preset = deepcopy(settings)
+        picks = self.state.get('draft_data').get('drafted_settings').get('picks')
+        data = self.state.get('draft_data').get('drafted_settings').get('data')
+
+        # Handled seperated tokensanity settings
+        if 'ow_tokens' in picks.keys() and 'dungeon_tokens' in picks.keys():
+            data.update({'tokensanity': 'all'})
+
+        preset.update(data)
+
+        # If dungeon er is on, add logic_dc_scarecrow_gs to trick list
+        for setting in data.keys():
+            if setting == 'shuffle_dungeon_entrances' and data[setting] == 'simple':
+                preset['allowed_tricks'].append('logic_dc_scarecrow_gs')
+        return preset
+    
+class PlayerDraft(Handler):
+    """
+    Class for handling draft-style races
+    """
+    def __init__(self, entrants, settings_pool, config, qual_data):
+        super().__init__(settings_pool)
+        _, *self.draftees, self.is_tournament_race, self.max_bans, self.max_picks = config
+        self.complete_settings_pool = self.major_settings_pool | self.minor_settings_pool
+        self.ban_count = 0
+        self.pick_count = 0
+        self.player_bans = {}
+        self.player_picks = {}
+        self.current_selector = None
+        self.determine_higher_seed(entrants, qual_data)
+
+    def determine_higher_seed(self, entrants, qual_data):
+        _draftees = []
+        # Sort by qualifier placement
+        if self.is_tournament_race:
+            placements = qual_data
+            for draftee in self.draftees:
+                for place in placements:
+                    if draftee == place['name'].lower():
+                        _draftees.append({'name': draftee, 'place': place['place']})
+            self.draftees = sorted(_draftees, key=lambda draftee: draftee['place'])
+        # Sort by racetime.gg points
+        else:
+            for draftee in self.draftees:
+                for entrant in entrants:
+                    if draftee == entrant['user']['name'].lower():
+                        _draftees.append({'name': draftee, 'score': entrant['score'] if entrant.get('score') else 0})
+            self.draftees = sorted(_draftees, key=lambda draftee: draftee['score'], reverse=True)
+
+    def assign_draft_order(self, reply_to):
+        pass
+
+    def skip_ban(self):
+        pass
+
+    def ban_setting(self):
+        pass
+
+    def pick_setting(self):
+        pass
+
+    def send_available_settings(self):
+        pass
+
+class RandomDraft(Handler):
+    """
+    Class for handling auto-select-style races
+    """
+    def __init__(self, settings_pool, config):
+        super().__init__(settings_pool)
+        _, self.is_tournament_race, self.num_settings = config
+        self.selected_settings = {}
+
+    def select_random_settings(self):
+        _num_settings = int(self.num_settings)
+        _generator_data = deepcopy(self.generator_data)
+        count = 0
+        while count < _num_settings:
+            # Select from major pool
+            if count < (_num_settings / 2):
+                pool = deepcopy(self.major_settings_pool)
+            # Select from minor pool
+            else:
+                pool = deepcopy(self.minor_settings_pool)
+            name = random.choice(list(pool))
+            setting = random.choice(list(pool[name]))
+            for key, value in pool[name][setting].items():
+                _generator_data.update({
+                    key: value
+                })
+            pool.pop(name)
+            self.selected_settings.update({
+                name: setting
+            })
+            count += 1

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -4,6 +4,7 @@ import datetime
 import re
 import random
 from racetime_bot import RaceHandler, monitor_cmd, can_moderate, can_monitor, msg_actions
+from .draft import PlayerDraft, RandomDraft
 
 
 def natjoin(sequence, default):
@@ -128,6 +129,20 @@ class RandoHandler(RaceHandler):
                             ),
                         ),
                     ),
+                    msg_actions.Action(
+                        label='Draft seed',
+                        help_text='Initialize a draft',
+                        message='!draft ${race_type}',
+                        submit='Begin',
+                        survey=msg_actions.Survey(
+                            msg_actions.RadioInput(
+                                name='race_type',
+                                label='Race type',
+                                options={'normal': 'Player draft', 'random': 'Auto-select settings'},
+                                default='normal'
+                            )
+                        )
+                    ),
                     msg_actions.ActionLink(
                         label='Help',
                         url='https://github.com/deains/ootr-randobot/blob/master/COMMANDS.md',
@@ -135,16 +150,13 @@ class RandoHandler(RaceHandler):
                 ],
                 pinned=True,
             )
-            await self.send_message(
-                'If this is a draft race, use !s7 tournament for official matches, '
-                'otherwise use !s7 <draft|random>'
-            )
-            self.state.setdefault('draft_data', {})
             self.state['intro_sent'] = True
         if 'locked' not in self.state:
             self.state['locked'] = False
         if 'fpa' not in self.state:
             self.state['fpa'] = False
+        if 'draft_status' not in self.state:
+            self.state['draft_status'] = None
 
     async def end(self):
         if self.state.get('pinned_msg'):
@@ -168,141 +180,146 @@ class RandoHandler(RaceHandler):
             del self.state['pinned_msg']
 
     @monitor_cmd
-    async def ex_s7(self, args, message):
+    async def ex_draft(self, args, message):
         """
-        Handle !s7 commands.
+        Handle !draft commands.
 
         Set up room for Draft Mode.
         """
-        if self._race_in_progress():
+        if self._race_in_progress() or len(args) == 0 or len(args) > 2:
             return
-        
-        draft = self.state.get('draft_data')
-
-        # Handle valid arguments.
-        if len(args) == 0:
+        elif len(self.data.get('entrants')) < 2:
             await self.send_message(
-                'Invalid format. Use !s7 <tournament|draft|random|cancel>.'
+                'At least two entrants must be present before beginning a draft.'
             )
             return
-        elif len(args) == 1 and args[0] in ('tournament', 'draft', 'random', 'qualifier', 'cancel'):
-            if args[0] in ('tournament', 'draft', 'random') and not draft.get('enabled'):
-                # Requires more than one user to enable Draft Mode.
-                if self.data.get('entrants_count') < 2:
+        if len(args) == 1:
+            if args[0] in ('normal', 'random') and not self.state.get('draft_data'):
+                self.state['draft_status'] = 'setup'
+                await self.unpin_message(self.state['pinned_msg'])
+                await self.send_message(
+                    'Welcome to OoTR Draft Mode!'
+                )
+                if args[0] == 'normal':
                     await self.send_message(
-                        'At least two runners must be present before enabling Draft Mode.'
+                        'Configure the draft settings with the buttons below.',
+                        actions=[
+                            msg_actions.Action(
+                                label='Configure draft',
+                                help_text='Configure draft settings',
+                                submit='Confirm',
+                                message='!config draft ${draftees} ${is_tournament_race} ${total_bans} ${total_picks}',
+                                survey=msg_actions.Survey(
+                                    msg_actions.SelectInput(
+                                        name='total_bans',
+                                        label='Total bans',
+                                        options={'2': '2', '4': '4', '6': '6'},
+                                        default='2'
+                                    ),
+                                    msg_actions.SelectInput(
+                                        name='total_picks',
+                                        label='Total picks',
+                                        options={'2': '2', '4': '4', '6': '6'},
+                                        default='4'
+                                    ),
+                                    msg_actions.BoolInput(
+                                        name='is_tournament_race',
+                                        label='Tournament race'
+                                    ),
+                                    msg_actions.TextInput(
+                                        name='draftees',
+                                        label='Draftees (separated with a space)',
+                                        placeholder='ex: Player1 Player2 Player3'
+                                    )
+                                )
+                            ),
+                            msg_actions.Action(
+                                label='Cancel draft',
+                                message='!draft cancel',
+                            )
+                        ]
                     )
-                    return
-                draft.update({
-                    'enabled': True,
-                    'race_type': args[0]
-                    })
-                await self.send_message(
-                    'Welcome to OoTR Draft Mode! '
-                    'You can disable Draft Mode with !s7 cancel.'
-                ),
-                await self.send_message(
-                    f'This is a "{args[0]}" race.'
-                )
-                # Always enable FPA for official matches.
-                if draft.get('race_type') == 'tournament':
-                    await self.ex_fpa(['on'], message)
-                # Add necessary property for random practice races and exit draft function
-                elif draft.get('race_type') == 'random':
-                    draft.update({
-                        'auto_draft': True,
-                        'status': 'seed_rolled',
-                        'available_settings': self.zsr.load_available_settings(),
-                        'drafted_settings': {
-                            'picks': {},
-                            'data': {}
-                        }
-                    })
+                elif args[0] == 'random':
                     await self.send_message(
-                        f'Use !seed 15 minutes prior to race start for a seed.'
+                        'Configure the amount of settings to change with the buttons below.',
+                        actions=[
+                            msg_actions.Action(
+                                label='Configure seed',
+                                help_text='Configure seed settings',
+                                submit='Confirm',
+                                message='!config random ${is_tournament_race} ${total_settings}',
+                                survey=msg_actions.Survey(
+                                    msg_actions.SelectInput(
+                                        name='total_settings',
+                                        label='Total # of random settings',
+                                        options={'2': '2', '4': '4', '6': '6'},
+                                        default='4'
+                                    ),
+                                    msg_actions.BoolInput(
+                                        name='is_tournament_race',
+                                        label='Qualifier race'
+                                    )
+                                )
+                            ),
+                            msg_actions.Action(
+                                label='Cancel draft',
+                                message='!draft cancel',
+                            )
+                        ]
                     )
-                    return
-                    
-                entrants = await self.determine_higher_seed()
-
-                # If we can't seed players, exit Draft Mode.
-                if len(entrants) < 2:
-                    await self.send_message(
-                            'Error fetching racer data. Exiting Draft Mode...'
-                        ),
-                    await self.ex_s7(['cancel'], message)
-                    return
-                await self.send_message(
-                    f"{entrants[0].get('name')}, please select whether or not to ban first with !first or !second."
-                )
-                draft.update({
-                    'racers': entrants,
-                    'status': 'select_order',
-                    'current_selector': None,
-                    'ban_count': 0,
-                    'pick_count': 0,
-                    'available_settings': self.zsr.load_available_settings(),
-                    'drafted_settings': {
-                        'picks': {},
-                        'data': {}
-                    },
-                })
-            elif args[0] == 'qualifier' and not draft.get('enabled'):
-                # Restrict qualifier argument to Race Moderators.
-                if not can_moderate(message):
-                    return
-                draft.update({
-                    'enabled': True,
-                    'race_type': args[0],
-                    'status': 'seed_rolled',
-                    'available_settings': self.zsr.load_available_settings(),
-                    'drafted_settings': {
-                        'picks': {},
-                        'data': {}
-                    }
-                })
-                await self.send_message(
-                    'Welcome to OoTR Draft Mode! '
-                    'You can disable Draft Mode with !s7 cancel.'
-                ),
-                await self.send_message(
-                    f'This is a "{args[0]}" race. Race monitors, use !seed 15 minutes prior to race start for a seed.'
-                )
-            elif args[0] in ('tournament', 'draft', 'random', 'qualifier') and draft.get('enabled'):
-                await self.send_message(
-                    'Draft Mode is already enabled.'
-                )
             elif args[0] == 'cancel':
-                if draft.get('enabled'):
-                    if self.state.get('seed_id') and not can_moderate(message):
-                        await self.send_message(
-                            'You may not exit Draft Mode once the seed is rolled.'
-                        )
-                        return
-                    if draft.get('race_type') == 'tournament':
-                        # Only allow Race Moderators to cancel once drafting is complete.
-                        if draft.get('status') == 'complete' and not can_moderate(message):
+                if self.state['draft_status'] is not None:
+                    if self.state.get('draft_data'):
+                        if self.state.get('seed_id') and not can_moderate(message):
                             await self.send_message(
-                                'Drafting already complete. Contact a Race Moderator for assistance.'
+                                'Only a race moderator can cancel the draft once the seed is rolled.'
                             )
                             return
-                        await self.ex_fpa(['off'], message),
-                    # Only allow Race Moderators to cancel qualifier races.
-                    elif draft.get('race_type') == 'qualifier':
-                        if not can_moderate(message):
-                            return
+                        await self.ex_fpa(['off'], message)
+                        del self.state['draft_data']
+                    await self.pin_message(self.state['pinned_msg'])
                     await self.send_message(
-                        'Draft Mode has been disabled.'
+                        'The draft has been canceled.'
                     )
-                    draft.clear()
+                    self.state['draft_status'] = None
                     return
                 await self.send_message(
-                    'Draft Mode is currently disabled.'
+                    'The draft has not been initialized.'
                 )
+
+    @monitor_cmd
+    async def ex_config(self, args, message):
+        """
+        Helper function for !draft
+        """
+        if self._race_in_progress() or len(args) == 0 or self.state['draft_status'] != 'setup':
             return
-        await self.send_message(
-            'Invalid option. Available options are: tournament, draft, random, cancel.'
-        )
+        if not await self.logic_draft_instance(args):
+            return
+        if args[0] == 'draft':
+            self.state['draft_data'] = PlayerDraft(self.data['entrants'], self.zsr.load_available_settings(), args, self.zsr.load_qualifier_placements())
+            if self.state['draft_data'].is_tournament_race:
+                await self.ex_fpa(['on'], message)
+            await self.send_message(
+                f"@{self.state['draft_data'].draftees[0]['name'].capitalize()}, would you like to ban first or second?",
+                actions=[
+                    msg_actions.Action(
+                        label='First',
+                        message='!first'
+                    ),
+                    msg_actions.Action(
+                        label='Second',
+                        message='!second'
+                    ),
+                    msg_actions.Action(
+                        label='Cancel draft',
+                        message='!draft cancel'
+                    )
+                ]
+            )
+        elif args[0] == 'random':
+            self.state['draft_data'] = RandomDraft(self.zsr.load_available_settings(), args)
+        self.state['draft_status'] = 'drafting_order'
 
     async def ex_first(self, args, message):
         """
@@ -310,27 +327,36 @@ class RandoHandler(RaceHandler):
 
         Allow higher-seeded player to pick first.
         """
-        draft = self.state.get('draft_data')
-        if self._race_in_progress() or not draft.get('status') == 'select_order':
+        if self._race_in_progress() or self.state['draft_status'] != 'drafting_order':
             return
-        
         reply_to = message.get('user', {}).get('name')
-        racer = draft.get('racers')
-
-        # Compare sender to draft_data 
-        if racer[0].get('name') != reply_to:
-            return
-        draft.update({'current_selector': racer[0].get('name')})
-        await self.send_message(
-            f'{reply_to}, remove a setting with !ban <setting>.'
-        )
-        await self.send_message(
-            'Use !settings for available options.'
-        )
-        await self.send_message(
-            'Use !skip to avoid removing a setting.'
-        )
-        draft.update({'status': 'ban'})
+        if self.state['draft_data'].assign_first_pick(reply_to):
+            await self.send_message(
+                f"{reply_to} has elected to go first. Select a setting to lock in or skip.",
+                actions=[
+                    msg_actions.Action(
+                        label='Select setting',
+                        message='!ban {setting}',
+                        submit='Select',
+                        survey=msg_actions.Survey(
+                            msg_actions.SelectInput(
+                                name='setting',
+                                label='Setting to lock in',
+                                options={setting: setting for setting in self.state['draft_data'].complete_settings_pool}
+                            )
+                        )
+                    ),
+                    msg_actions.Action(
+                        label='Skip',
+                        message='!skip',
+                    ),
+                    msg_actions.Action(
+                        label='Cancel draft',
+                        message='!draft cancel'
+                    )
+                ]
+            )
+            self.state['draft_status'] = 'player_bans'
 
     async def ex_second(self, args, message):
         """
@@ -338,27 +364,26 @@ class RandoHandler(RaceHandler):
 
         Allow higher-seeded player to pick second.
         """
-        draft = self.state.get('draft_data')
-        if self._race_in_progress() or not draft.get('status') == 'select_order':
+        if self._race_in_progress() or self.state['draft_status'] != 'drafting_order':
             return
-        
-        reply_to = message.get('user', {}).get('name')
-        racer = draft.get('racers')
+        self.state['']
+        # reply_to = message.get('user', {}).get('name')
+        # racer = draft.get('racers')
 
-        # Compare sender to draft_data 
-        if racer[0].get('name') != reply_to:
-            return
-        draft.update({'current_selector': racer[1].get('name')})
-        await self.send_message(
-            f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
-        )
-        await self.send_message(
-            'Use !settings for available options.'
-        )
-        await self.send_message(
-            'Use !skip to avoid removing a setting.'
-        )
-        draft.update({'status': 'ban'})
+        # # Compare sender to draft_data 
+        # if racer[0].get('name') != reply_to:
+        #     return
+        # draft.update({'current_selector': racer[1].get('name')})
+        # await self.send_message(
+        #     f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
+        # )
+        # await self.send_message(
+        #     'Use !settings for available options.'
+        # )
+        # await self.send_message(
+        #     'Use !skip to avoid removing a setting.'
+        # )
+        # draft.update({'status': 'ban'})
             
     async def ex_ban(self, args, message):
         """
@@ -366,97 +391,98 @@ class RandoHandler(RaceHandler):
 
         Force setting to default value.
         """
-        draft = self.state.get('draft_data')
-        if self._race_in_progress() or draft.get('status') != 'ban':
+        if self._race_in_progress() or self.state['draft_status'] != 'player_bans':
             return
-        
-        reply_to = message.get('user', {}).get('name')
-        racer = draft.get('racers')
-        major_pool = draft.get('available_settings').get('major')
-        minor_pool = draft.get('available_settings').get('minor')
+        draft = self.state['draft_data']
+        draft.ban_setting(args, message)
 
-        if reply_to == draft.get('current_selector'):
-            if len(args) == 1 and (args[0] in major_pool.keys() or args[0] in minor_pool.keys()):
-                await self.send_message(
-                    f'{args[0].capitalize()} will be removed from the pool.'
-                )
-                # Remove setting from available settings pool
-                major_pool.pop(args[0]) if args[0] in major_pool.keys() else minor_pool.pop(args[0])
-                # Advance draft state.
-                draft['ban_count'] += 1
-                # Change player turn post setting selection.
-                if reply_to == racer[0].get('name'):
-                    draft.update({'current_selector': racer[1].get('name')})
-                elif reply_to == racer[1].get('name'):
-                    draft.update({'current_selector': racer[0].get('name')})
-                # Move to pick phase once each player has banned.
-                if draft.get('ban_count') == 2:
-                    draft.update({'status': 'major_pick'})
-                    await self.send_message(
-                        'All bans have been recorded.'
-                    )
-                    await self.send_message(
-                        f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
-                    )
-                    await self.send_message(
-                        'Use !settings for of available options.'
-                    )
-                    return
-                await self.send_message(
-                    f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
-                )
-                await self.send_message(
-                    'Use !settings for available options.'
-                )
-                await self.send_message(
-                    'Use !skip to avoid removing a setting.'
-                )
-                return
-            # Handle invalid format and unknown arguments
-            await self.send_message(
-                'Invalid option. Use !settings for available options.'
-            )
+    #     reply_to = message.get('user', {}).get('name')
+    #     racer = draft.get('racers')
+    #     major_pool = draft.get('available_settings').get('major')
+    #     minor_pool = draft.get('available_settings').get('minor')
+
+    #     if reply_to == draft.get('current_selector'):
+    #         if len(args) == 1 and (args[0] in major_pool.keys() or args[0] in minor_pool.keys()):
+    #             await self.send_message(
+    #                 f'{args[0].capitalize()} will be removed from the pool.'
+    #             )
+    #             # Remove setting from available settings pool
+    #             major_pool.pop(args[0]) if args[0] in major_pool.keys() else minor_pool.pop(args[0])
+    #             # Advance draft state.
+    #             draft['ban_count'] += 1
+    #             # Change player turn post setting selection.
+    #             if reply_to == racer[0].get('name'):
+    #                 draft.update({'current_selector': racer[1].get('name')})
+    #             elif reply_to == racer[1].get('name'):
+    #                 draft.update({'current_selector': racer[0].get('name')})
+    #             # Move to pick phase once each player has banned.
+    #             if draft.get('ban_count') == 2:
+    #                 draft.update({'status': 'major_pick'})
+    #                 await self.send_message(
+    #                     'All bans have been recorded.'
+    #                 )
+    #                 await self.send_message(
+    #                     f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
+    #                 )
+    #                 await self.send_message(
+    #                     'Use !settings for of available options.'
+    #                 )
+    #                 return
+    #             await self.send_message(
+    #                 f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
+    #             )
+    #             await self.send_message(
+    #                 'Use !settings for available options.'
+    #             )
+    #             await self.send_message(
+    #                 'Use !skip to avoid removing a setting.'
+    #             )
+    #             return
+    #         # Handle invalid format and unknown arguments
+    #         await self.send_message(
+    #             'Invalid option. Use !settings for available options.'
+    #         )
 
     async def ex_skip(self, args, message):
-        draft = self.state.get('draft_data')
-        if self._race_in_progress() or draft.get('status') != 'ban':
+        if self._race_in_progress() or self.state['draft_status'] != 'player_bans':
             return
-        
-        reply_to = message.get('user', {}).get('name')
-        racer = draft.get('racers')
+        draft = self.state['draft_data']
+        draft.skip_ban(args, message)
+        # reply_to = message.get('user', {}).get('name')
+        # racer = draft.get('racers')
 
-        if reply_to == draft.get('current_selector'):
-            await self.send_message(
-                f'{reply_to} has chosen to skip removing a setting.'
-            )
-            # Advance draft state.
-            draft['ban_count'] += 1
-            # Change player turn post setting selection.
-            if reply_to == racer[0].get('name'):
-                draft.update({'current_selector': racer[1].get('name')})
-            elif reply_to == racer[1].get('name'):
-                draft.update({'current_selector': racer[0].get('name')})
-            if draft.get('ban_count') < 2:
-                await self.send_message(
-                    f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
-                )
-                await self.send_message(
-                    'Use !skip to avoid removing a setting.'
-                )
-                await self.send_message(
-                    'Use !settings for available options.'
-                )
-            elif draft.get('ban_count') == 2:
-                draft.update({'status': 'major_pick'})
-                await self.send_message(
-                    'All bans have been recorded.'
-                )
-                await self.send_message(
-                    f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
-                )
-                await self.send_message(
-                    'Use !settings for of available options.'
-                )
+        # if reply_to == draft.get('current_selector'):
+        #     await self.send_message(
+        #         f'{reply_to} has chosen to skip removing a setting.'
+        #     )
+        #     # Advance draft state.
+        #     draft['ban_count'] += 1
+        #     # Change player turn post setting selection.
+        #     if reply_to == racer[0].get('name'):
+        #         draft.update({'current_selector': racer[1].get('name')})
+        #     elif reply_to == racer[1].get('name'):
+        #         draft.update({'current_selector': racer[0].get('name')})
+        #     if draft.get('ban_count') < 2:
+        #         await self.send_message(
+        #             f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
+        #         )
+        #         await self.send_message(
+        #             'Use !skip to avoid removing a setting.'
+        #         )
+        #         await self.send_message(
+        #             'Use !settings for available options.'
+        #         )
+        #     elif draft.get('ban_count') == 2:
+        #         draft.update({'status': 'major_pick'})
+        #         await self.send_message(
+        #             'All bans have been recorded.'
+        #         )
+        #         await self.send_message(
+        #             f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
+        #         )
+        #         await self.send_message(
+        #             'Use !settings for of available options.'
+        #         )
 
     async def ex_pick(self, args, message):
         """
@@ -931,82 +957,49 @@ class RandoHandler(RaceHandler):
             for name, preset in self.zsr.presets.items():
                 await self.send_message('%s – %s' % (name, preset['full_name']))
 
-    async def determine_higher_seed(self):
-        entrants = []
-        # Return list sorted by Qualifier ranking
-        if self.state.get('draft_data').get('race_type') == 'tournament':
-            placements = self.zsr.load_qualifier_placements()
-            for entrant in self.data.get('entrants'):
-                for place in placements:
-                    if entrant.get('user').get('id') == place.get('id'):
-                        entrants.append({'name': entrant.get('user').get('name'), 'rank': place.get('place')})
-            return sorted(entrants, key=lambda entrant: entrant.get('rank'))    
-        # Return list sorted by RaceTime points
-        elif self.state.get('draft_data').get('race_type') == 'draft':
-            for entrant in self.data.get('entrants'):
-                entrants.append({'name': entrant.get('user').get('name'), 'score': (entrant.get('score') if entrant.get('score') else 0)})
-            return sorted(entrants, key=lambda entrant: entrant.get('score'), reverse=True)
-
-    async def handle_random_seed(self, encrypt, dev, reply_to):
-        draft = self.state.get('draft_data')
-        available_settings = draft.get('available_settings')
-        drafted_settings = draft.get('drafted_settings')
-        count = 0
-
-        while count < 4:
-            # Major pick
-            if count < 2:
-                pool = available_settings.get('major')
-            # Minor pick
-            else:
-                pool = available_settings.get('minor')
-            name = random.choice(list(pool.keys()))
-            setting = random.choice(list(pool.get(name).keys()))
-            for key, value in pool.get(name).get(setting).items():
-                drafted_settings.get('data').update({
-                    key: value
-                })
-            pool.pop(name)
-            drafted_settings.get('picks').update({
-                name: setting
-            })
-            count += 1
-
-        await self.roll(
-            preset=None,
-            encrypt=encrypt,
-            dev=dev,
-            reply_to=reply_to,
-            settings=self.patch_settings()
-        )
-        if draft.get('race_type') == 'qualifier':
-            await self.send_message(
-                f'Race Monitors, use !settings 5 minutes before race start to reveal the selected settings.'
-            )
-            await self.send_message(
-                'Once revealed, the room will be locked from joining.'
-            )
-            return
-        await self.ex_settings('', '')
-
-    def patch_settings(self):
-        settings = self.zsr.presets.get('s7').get('settings')
-        preset = deepcopy(settings)
-        picks = self.state.get('draft_data').get('drafted_settings').get('picks')
-        data = self.state.get('draft_data').get('drafted_settings').get('data')
-
-        # Handled seperated tokensanity settings
-        if 'ow_tokens' in picks.keys() and 'dungeon_tokens' in picks.keys():
-            data.update({'tokensanity': 'all'})
-
-        preset.update(data)
-
-        # If dungeon er is on, add logic_dc_scarecrow_gs to trick list
-        for setting in data.keys():
-            if setting == 'shuffle_dungeon_entrances' and data[setting] == 'simple':
-                preset['allowed_tricks'].append('logic_dc_scarecrow_gs')
-
-        return preset
+    async def logic_draft_instance(self, args):
+        if args[0] == 'draft':
+            if len(args) < 6:
+                await self.send_message(
+                    'Invalid syntax. Use the buttons for assistance.'
+                )
+                return False
+            _, *draftees, is_tournament_race, max_bans, max_picks = args
+            for entrant in self.data['entrants']:
+                if entrant['user']['name'].lower() not in draftees:
+                    await self.send_message(
+                        'One or more supplied draftees are not in the room.'
+                    )
+                    return False
+            if is_tournament_race:
+                if max_bans != '2' or max_picks != '4':
+                    await self.send_message(
+                        'Draftees may only ban 2 settings and pick 4 settings for tournament races.'
+                    )
+                    return False
+                elif len(draftees) != 2:
+                    await self.send_message(
+                        'Only 2 draftees may participate in tournament races.'
+                    )
+                    return False
+            if len(draftees) < 2:
+                await self.send_message(
+                    'At least 2 draftees must be selected to draft settings.'
+                )
+                return False
+        elif args[0] == 'random':
+            if len(args) != 3:
+                await self.send_message(
+                    'Invalid syntax. Use the buttons for assistance.'
+                )
+                return False
+            _, is_tournament_race, num_settings = args
+            if is_tournament_race and num_settings != '2':
+                await self.send_message(
+                    'Only 2 settings may be changed in tournament races'
+                )
+                return False
+        return True
 
     def _race_in_progress(self):
         return self.data.get('status').get('value') in ('pending', 'in_progress')

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -193,108 +193,109 @@ class RandoHandler(RaceHandler):
                 'At least two entrants must be present before beginning a draft.'
             )
             return
-        if len(args) == 1:
-            if args[0] in ('normal', 'random') and not self.state.get('draft_data'):
-                self.state['draft_status'] = 'setup'
+        if args[0] in ('normal', 'random') and not self.state.get('draft_data'):
+            self.state['draft_status'] = 'setup'
+            if self.state.get('pinned_msg'):
                 await self.unpin_message(self.state['pinned_msg'])
+            await self.send_message(
+                'Welcome to OoTR Draft Mode!'
+            )
+            if args[0] == 'normal':
                 await self.send_message(
-                    'Welcome to OoTR Draft Mode!'
+                    'Configure the draft settings with the buttons below.',
+                    actions=[
+                        msg_actions.Action(
+                            label='Configure draft',
+                            help_text='Configure draft settings',
+                            submit='Confirm',
+                            message='!config draft ${draftees} ${is_tournament_race} ${bans_each} ${major_picks_each} ${minor_picks_each}',
+                            survey=msg_actions.Survey(
+                                msg_actions.SelectInput(
+                                    name='bans_each',
+                                    label='# Bans each',
+                                    options={'1': '1', '2': '2', '3': '3'},
+                                    default='1'
+                                ),
+                                msg_actions.SelectInput(
+                                    name='major_picks_each',
+                                    label='# Major picks each',
+                                    options={'1': '1', '2': '2', '3': '3'},
+                                    default='1'
+                                ),
+                                msg_actions.SelectInput(
+                                    name='minor_picks_each',
+                                    label='# Minor picks each',
+                                    options={'1': '1', '2': '2', '3': '3'},
+                                    default='1'
+                                ),
+                                msg_actions.BoolInput(
+                                    name='is_tournament_race',
+                                    label='Tournament race'
+                                ),
+                                msg_actions.TextInput(
+                                    name='draftees',
+                                    label='Draftees (case-insensitive)',
+                                    placeholder='ex: Player1 Player2 Player3'
+                                )
+                            )
+                        ),
+                        msg_actions.Action(
+                            label='Cancel draft',
+                            message='!draft cancel',
+                        )
+                    ]
                 )
-                if args[0] == 'normal':
-                    await self.send_message(
-                        'Configure the draft settings with the buttons below.',
-                        actions=[
-                            msg_actions.Action(
-                                label='Configure draft',
-                                help_text='Configure draft settings',
-                                submit='Confirm',
-                                message='!config draft ${draftees} ${is_tournament_race} ${bans_each} ${major_picks_each} ${minor_picks_each}',
-                                survey=msg_actions.Survey(
-                                    msg_actions.SelectInput(
-                                        name='bans_each',
-                                        label='# Bans each',
-                                        options={'1': '1', '2': '2', '3': '3'},
-                                        default='1'
-                                    ),
-                                    msg_actions.SelectInput(
-                                        name='major_picks_each',
-                                        label='# Major picks each',
-                                        options={'1': '1', '2': '2', '3': '3'},
-                                        default='1'
-                                    ),
-                                    msg_actions.SelectInput(
-                                        name='minor_picks_each',
-                                        label='# Minor picks each',
-                                        options={'1': '1', '2': '2', '3': '3'},
-                                        default='1'
-                                    ),
-                                    msg_actions.BoolInput(
-                                        name='is_tournament_race',
-                                        label='Tournament race'
-                                    ),
-                                    msg_actions.TextInput(
-                                        name='draftees',
-                                        label='Draftees (separated with a space)',
-                                        placeholder='ex: Player1 Player2 Player3'
-                                    )
+            elif args[0] == 'random':
+                await self.send_message(
+                    'Configure the amount of settings to change with the buttons below.',
+                    actions=[
+                        msg_actions.Action(
+                            label='Configure seed',
+                            help_text='Configure seed settings',
+                            submit='Confirm',
+                            message='!config random ${num_major_settings} ${num_minor_settings}',
+                            survey=msg_actions.Survey(
+                                msg_actions.SelectInput(
+                                    name='num_major_settings',
+                                    label='# Of random major settings',
+                                    options={'1': '1', '2': '2', '3': '3'},
+                                    default='2'
+                                ),
+                                msg_actions.SelectInput(
+                                    name='num_minor_settings',
+                                    label='# Of random minor settings',
+                                    options={'1': '1', '2': '2', '3': '3'},
+                                    default='2'
                                 )
-                            ),
-                            msg_actions.Action(
-                                label='Cancel draft',
-                                message='!draft cancel',
                             )
-                        ]
-                    )
-                elif args[0] == 'random':
-                    await self.send_message(
-                        'Configure the amount of settings to change with the buttons below.',
-                        actions=[
-                            msg_actions.Action(
-                                label='Configure seed',
-                                help_text='Configure seed settings',
-                                submit='Confirm',
-                                message='!config random ${num_major_settings} ${num_minor_settings}',
-                                survey=msg_actions.Survey(
-                                    msg_actions.SelectInput(
-                                        name='num_major_settings',
-                                        label='# Of random major settings',
-                                        options={'1': '1', '2': '2', '3': '3'},
-                                        default='2'
-                                    ),
-                                    msg_actions.SelectInput(
-                                        name='num_minor_settings',
-                                        label='# Of random minor settings',
-                                        options={'1': '1', '2': '2', '3': '3'},
-                                        default='2'
-                                    )
-                                )
-                            ),
-                            msg_actions.Action(
-                                label='Cancel draft',
-                                message='!draft cancel',
-                            )
-                        ]
-                    )
-            elif args[0] == 'cancel':
-                if self.state.get('draft_status') is not None:
-                    if self.state.get('draft_data'):
-                        if self.state.get('seed_id') and not can_moderate(message):
-                            await self.send_message(
-                                'Only a race moderator can cancel the draft once the seed is rolled.'
-                            )
-                            return
-                        if self.state.get('fpa') == True:
-                            await self.ex_fpa(['off'], message)
-                        del self.state['draft_data']
+                        ),
+                        msg_actions.Action(
+                            label='Cancel draft',
+                            message='!draft cancel',
+                        )
+                    ]
+                )
+        elif args[0] == 'cancel':
+            if self.state.get('draft_status') is not None:
+                if self.state.get('draft_data'):
+                    if self.state.get('seed_id') and not can_moderate(message):
+                        await self.send_message(
+                            'Only a race moderator can cancel the draft once the seed is rolled.'
+                        )
+                        return
+                    if self.state.get('fpa') == True:
+                        await self.ex_fpa(['off'], message)
+                    del self.state['draft_data']
+                if self.state.get('pinned_msg'):
                     await self.pin_message(self.state['pinned_msg'])
-                    await self.send_message(
-                        'The draft has been canceled.'
-                    )
-                    self.state['draft_status'] = None
-                    return
                 await self.send_message(
-                    'The draft has not been initialized.'
+                    'The draft has been canceled.'
                 )
+                self.state['draft_status'] = None
+                return
+            await self.send_message(
+                'The draft has not been initialized.'
+            )
 
     @monitor_cmd
     async def ex_config(self, args, message):
@@ -303,16 +304,17 @@ class RandoHandler(RaceHandler):
         """
         if self._race_in_progress() or len(args) == 0:
             return
-        if not await self.verify_args(args):
-            return
         if args[0] == 'draft' and self.state.get('draft_status') == 'setup':
-            self.state['draft_data'] = PlayerDraft(self.data['entrants'], self.zsr.load_available_settings(), args, self.zsr.load_qualifier_placements())
+            if not await self.parse_draft_args(args):
+                return
+            self.state['draft_data'] = PlayerDraft(self.zsr.load_available_settings(), args)
             self.state['draft_status'] = 'draft_order'
-            if self.state.get('draft_data').is_tournament_race:
-                await self.ex_fpa(['on'], message)
             if len(self.state.get('draft_data').draftees) == 2:
+                if self.state.get('draft_data').is_tournament_race:
+                    await self.ex_fpa(['on'], message)
+                self.state['draft_data'].determine_higher_seed(self.data['entrants'], self.zsr.load_qualifier_placements())
                 await self.send_message(
-                    f"@{self.state['draft_data'].draftees[0]['name'].capitalize()}, would you like to go first or second?",
+                    f"{self.state['draft_data'].draftees[0]['name']}, would you like to go first or second?",
                     actions=[
                         msg_actions.Action(
                             label='First',
@@ -372,7 +374,7 @@ class RandoHandler(RaceHandler):
             )
         elif args[0] == 'order' and self.state.get('draft_status') == 'draft_order':
             if len(self.state.get('draft_data').draftees) > 2:
-                self.state['draft_data'].assign_draft_order(None, args)
+                self.state['draft_data'].assign_draft_order(args, message)
 
     async def ex_first(self, args, message):
         """
@@ -380,24 +382,33 @@ class RandoHandler(RaceHandler):
 
         Allow higher-seeded player to pick first.
         """
-        if self._race_in_progress() or self.state.get('draft_status') != 'draft_order' or len(self.state.get('draft_data').draftees) > 2:
+        if (
+            self._race_in_progress()
+            or self.state.get('draft_status') != 'draft_order'
+            or len(self.state.get('draft_data').draftees) > 2
+            or message.get('user', {}).get('name') != self.state.get('draft_data').draftees[0]['name']
+        ):
             return
-        self.state['draft_data'].assign_draft_order(message, None)
+        self.state['draft_data'].assign_draft_order(args, message)
         self.state['draft_status'] = 'player_bans'
         await self.send_message(
-            f"@{self.state['draft_data'].current_selector}, Use the buttons below to lock in a setting.",
+            f"{self.state['draft_data'].current_selector}, Use the buttons below to lock in a setting.",
             actions=[
                 msg_actions.Action(
-                    label='Ban setting',
+                    label='Settings list',
                     message='!ban ${setting}',
                     submit='Confirm',
                     survey=msg_actions.Survey(
                         msg_actions.SelectInput(
                             name='setting',
-                            label='Setting to ban',
-                            options=self.state['draft_data'].send_available_settings()
+                            label='Lock in setting',
+                            options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
                         )
                     )
+                ),
+                msg_actions.Action(
+                    label='Skip turn',
+                    message='!skip'
                 ),
                 msg_actions.Action(
                     label='Cancel draft',
@@ -412,9 +423,40 @@ class RandoHandler(RaceHandler):
 
         Allow higher-seeded player to pick second.
         """
-        if self._race_in_progress() or self.state.get('draft_status') != 'draft_order' or len(self.state.get('draft_data').draftees) > 2:
+        if (
+            self._race_in_progress()
+            or self.state.get('draft_status') != 'draft_order'
+            or len(self.state.get('draft_data').draftees) > 2
+            or message.get('user', {}).get('name') != self.state.get('draft_data').draftees[0]['name']
+        ):
             return
-        self.state['draft_data'].assign_draft_order(message, None)
+        self.state['draft_data'].assign_draft_order(args, message)
+        self.state['draft_status'] = 'player_bans'
+        await self.send_message(
+            f"{self.state['draft_data'].current_selector}, Use the buttons below to lock in a setting.",
+            actions=[
+                msg_actions.Action(
+                    label='Settings list',
+                    message='!ban ${setting}',
+                    submit='Confirm',
+                    survey=msg_actions.Survey(
+                        msg_actions.SelectInput(
+                            name='setting',
+                            label='Lock in setting',
+                            options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
+                        )
+                    )
+                ),
+                msg_actions.Action(
+                    label='Skip turn',
+                    message='!skip'
+                ),
+                msg_actions.Action(
+                    label='Cancel draft',
+                    message='!draft cancel'
+                )
+            ]
+        )
             
     async def ex_ban(self, args, message):
         """
@@ -424,94 +466,117 @@ class RandoHandler(RaceHandler):
         """
         if self._race_in_progress() or self.state.get('draft_status') != 'player_bans':
             return
-
-    #     reply_to = message.get('user', {}).get('name')
-    #     racer = draft.get('racers')
-    #     major_pool = draft.get('available_settings').get('major')
-    #     minor_pool = draft.get('available_settings').get('minor')
-
-    #     if reply_to == draft.get('current_selector'):
-    #         if len(args) == 1 and (args[0] in major_pool.keys() or args[0] in minor_pool.keys()):
-    #             await self.send_message(
-    #                 f'{args[0].capitalize()} will be removed from the pool.'
-    #             )
-    #             # Remove setting from available settings pool
-    #             major_pool.pop(args[0]) if args[0] in major_pool.keys() else minor_pool.pop(args[0])
-    #             # Advance draft state.
-    #             draft['ban_count'] += 1
-    #             # Change player turn post setting selection.
-    #             if reply_to == racer[0].get('name'):
-    #                 draft.update({'current_selector': racer[1].get('name')})
-    #             elif reply_to == racer[1].get('name'):
-    #                 draft.update({'current_selector': racer[0].get('name')})
-    #             # Move to pick phase once each player has banned.
-    #             if draft.get('ban_count') == 2:
-    #                 draft.update({'status': 'major_pick'})
-    #                 await self.send_message(
-    #                     'All bans have been recorded.'
-    #                 )
-    #                 await self.send_message(
-    #                     f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
-    #                 )
-    #                 await self.send_message(
-    #                     'Use !settings for of available options.'
-    #                 )
-    #                 return
-    #             await self.send_message(
-    #                 f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
-    #             )
-    #             await self.send_message(
-    #                 'Use !settings for available options.'
-    #             )
-    #             await self.send_message(
-    #                 'Use !skip to avoid removing a setting.'
-    #             )
-    #             return
-    #         # Handle invalid format and unknown arguments
-    #         await self.send_message(
-    #             'Invalid option. Use !settings for available options.'
-    #         )
-
+        if len(self.state.get('draft_data').player_bans) >= int(self.state.get('draft_data').bans_each) * len(self.state.get('draft_data').draftees):
+            return
+        if self.state['draft_data'].ban_setting(args, message):
+            await self.send_message(
+                f"{self.state['draft_data'].current_selector}, Use the buttons below to lock in a setting.",
+                actions=[
+                    msg_actions.Action(
+                        label='Settings list',
+                        message='!ban ${setting}',
+                        submit='Confirm',
+                        survey=msg_actions.Survey(
+                            msg_actions.SelectInput(
+                                name='setting',
+                                label='Lock in setting',
+                                options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
+                            )
+                        )
+                    ),
+                    msg_actions.Action(
+                        label='Skip turn',
+                        message='!skip'
+                    ),
+                    msg_actions.Action(
+                        label='Cancel draft',
+                        message='!draft cancel'
+                    )
+                ]
+            )
+            return
+        await self.send_message(
+            'All bans have been recorded.'
+        )
+        self.state['draft_status'] = 'player_picks'
+        await self.send_message(
+            f"{self.state['draft_data'].current_selector}, Use the buttons below to modify a major setting.",
+            actions=[
+                msg_actions.Action(
+                    label='Settings list',
+                    message='!pick ${setting}',
+                    submit='Confirm',
+                    survey=msg_actions.Survey(
+                        msg_actions.SelectInput(
+                            name='setting',
+                            label='Modify a setting',
+                            options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
+                        )
+                    )
+                ),
+                msg_actions.Action(
+                    label='Cancel draft',
+                    message='!draft cancel'
+                )
+            ]
+        )
+        
     async def ex_skip(self, args, message):
         if self._race_in_progress() or self.state.get('draft_status') != 'player_bans':
             return
+        if self.state['draft_data'].skip_ban(message):
+            await self.send_message(
+                f"{self.state['draft_data'].current_selector}, Use the buttons below to lock in a setting.",
+                actions=[
+                    msg_actions.Action(
+                        label='Settings list',
+                        message='!ban ${setting}',
+                        submit='Confirm',
+                        survey=msg_actions.Survey(
+                            msg_actions.SelectInput(
+                                name='setting',
+                                label='Lock in setting',
+                                options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
+                            )
+                        )
+                    ),
+                    msg_actions.Action(
+                        label='Skip turn',
+                        message='!skip'
+                    ),
+                    msg_actions.Action(
+                        label='Cancel draft',
+                        message='!draft cancel'
+                    )
+                ]
+            )
+            return
+        await self.send_message(
+            'All bans have been recorded.'
+        )
+        self.state['draft_status'] = 'player_picks'
+        await self.send_message(
+            f"{self.state['draft_data'].current_selector}, Use the buttons below to modify a major setting.",
+            actions=[
+                msg_actions.Action(
+                    label='Settings list',
+                    message='!pick ${setting}',
+                    submit='Confirm',
+                    survey=msg_actions.Survey(
+                        msg_actions.SelectInput(
+                            name='setting',
+                            label='Modify a setting',
+                            options=self.state['draft_data'].send_available_settings(self.state['draft_status'])
+                        )
+                    )
+                ),
+                msg_actions.Action(
+                    label='Cancel draft',
+                    message='!draft cancel'
+                )
+            ]
+        )
         
-        # reply_to = message.get('user', {}).get('name')
-        # racer = draft.get('racers')
-
-        # if reply_to == draft.get('current_selector'):
-        #     await self.send_message(
-        #         f'{reply_to} has chosen to skip removing a setting.'
-        #     )
-        #     # Advance draft state.
-        #     draft['ban_count'] += 1
-        #     # Change player turn post setting selection.
-        #     if reply_to == racer[0].get('name'):
-        #         draft.update({'current_selector': racer[1].get('name')})
-        #     elif reply_to == racer[1].get('name'):
-        #         draft.update({'current_selector': racer[0].get('name')})
-        #     if draft.get('ban_count') < 2:
-        #         await self.send_message(
-        #             f"{draft.get('current_selector')}, remove a setting with !ban <setting>."
-        #         )
-        #         await self.send_message(
-        #             'Use !skip to avoid removing a setting.'
-        #         )
-        #         await self.send_message(
-        #             'Use !settings for available options.'
-        #         )
-        #     elif draft.get('ban_count') == 2:
-        #         draft.update({'status': 'major_pick'})
-        #         await self.send_message(
-        #             'All bans have been recorded.'
-        #         )
-        #         await self.send_message(
-        #             f"{draft.get('current_selector')}, modify a major setting with !pick <setting> <value>."
-        #         )
-        #         await self.send_message(
-        #             'Use !settings for of available options.'
-        #         )
-
     async def ex_pick(self, args, message):
         """
         Handles !pick commands.
@@ -520,7 +585,9 @@ class RandoHandler(RaceHandler):
         """
         if self._race_in_progress() or self.state.get('draft_status') != 'player_picks':
             return
-        
+        self.state['draft_data'].pick_setting(args, message)
+
+
         # draft = self.state.get('draft_data')
         # if self._race_in_progress() or not draft.get('enabled') or not draft.get('status') in ['major_pick', 'minor_pick']:
         #     return
@@ -694,6 +761,9 @@ class RandoHandler(RaceHandler):
         if self._race_in_progress():
             return
         if self.state.get('draft_status') is not None:
+            await self.send_message(
+                'You must cancel the draft to use these commands.'
+            )
             return
         await self.roll_and_send(args, message, encrypt=False, dev=False)
 
@@ -704,6 +774,9 @@ class RandoHandler(RaceHandler):
         if self._race_in_progress():
             return
         if self.state.get('draft_status') is not None:
+            await self.send_message(
+                'You must cancel the draft to use these commands.'
+            )
             return
         await self.send_presets(False)
 
@@ -714,6 +787,9 @@ class RandoHandler(RaceHandler):
         if self._race_in_progress():
             return
         if self.state.get('draft_status') is not None:
+            await self.send_message(
+                'You must cancel the draft to use these commands.'
+            )
             return
         await self.send_presets(True)
 
@@ -873,31 +949,31 @@ class RandoHandler(RaceHandler):
             for name, preset in self.zsr.presets.items():
                 await self.send_message('%s – %s' % (name, preset['full_name']))
 
-    async def verify_args(self, args):
+    async def parse_draft_args(self, args):
         if args[0] == 'draft':
-            if len(args) < 6:
+            if len(args) < 7:
                 await self.send_message(
                     'Invalid syntax. Use the buttons for assistance.'
                 )
-                return False
+                return
             _, *draftees, _, _, _, _ = args
+            if len(draftees) < 2:
+                await self.send_message(
+                    'At least 2 draftees must be selected before continuing.'
+                )
+                return
             for entrant in self.data['entrants']:
                 if entrant['user']['name'].lower() not in draftees:
                     await self.send_message(
                         'One or more supplied draftees are not in the room.'
                     )
-                    return False
-            if len(draftees) < 2:
-                await self.send_message(
-                    'At least 2 draftees must be selected before continuing.'
-                )
-                return False
+                    return
         elif args[0] == 'random':
             if len(args) != 3:
                 await self.send_message(
                     'Invalid syntax. Use the buttons for assistance.'
                 )
-                return False
+                return
         return True
 
     def _race_in_progress(self):

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -283,7 +283,7 @@ class ZSR:
                     }
                 },
                 "ow_tokens": {
-                    "__setting": "Overworld Tokens",
+                    "__setting": "Overworld Token Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -301,7 +301,7 @@ class ZSR:
                     }
                 },
                 "dungeon_tokens": {
-                    "__setting": "Dungeon Tokens",
+                    "__setting": "Dungeon Token Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -520,7 +520,7 @@ class ZSR:
                     }
                 },
                 "rupees": {
-                    "__setting": "Start with Rupees",
+                    "__setting": "Start with Max Rupees",
                     "default": "off",
                     "options": {
                         "off": {
@@ -530,7 +530,7 @@ class ZSR:
                             }
                         },
                         "on": {
-                            "name": "On",
+                            "name": "On (fills wallet on upgrade)",
                             "data": {
                                 "start_with_rupees": True
                             }
@@ -538,7 +538,7 @@ class ZSR:
                     }
                 },
                 "cuccos": {
-                    "__setting": "Chicken Count",
+                    "__setting": "Anju's Chicken Count",
                     "default": "7",
                     "options": {
                         "7": {
@@ -701,7 +701,7 @@ class ZSR:
                     }
                 },
                 "beans_planted": {
-                    "__setting": "Planted Magic Beans",
+                    "__setting": "Magic Beans Planted",
                     "default": "off",
                     "options": {
                         "off": {

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -102,7 +102,7 @@ class ZSR:
             return latest_dev_version, True
         return latest_dev_version, False
 
-    def roll_seed(self, preset, encrypt, dev, settings, race_type):
+    def roll_seed(self, preset, encrypt, dev, settings):
         """
         Generate a seed and return its public URL.
         """
@@ -131,8 +131,6 @@ class ZSR:
             params['encrypt'] = 'true'
         if encrypt and dev:
             params['locked'] = 'true'
-        if race_type == 'qualifier':
-            params['hideSettings'] = 'true'
         if dev:
             params['version'] = 'dev_' + latest_dev_version
         data = requests.post(self.seed_endpoint, req_body, params=params,
@@ -180,13 +178,13 @@ class ZSR:
                     "default": "meds",
                     "options": {
                         "meds": {
-                            "name": "6 meds, No GCBK",
+                            "name": "6 meds - No GCBK",
                             "data": {
                                 "bridge": "medallions"   
                             }
                         },
                         "open": {
-                            "name": "Open, 6 med GCBK",
+                            "name": "Open - 6 med GCBK",
                             "data": {
                                 "bridge": "medallions",
                                 "shuffle_ganon_bosskey": "medallions"
@@ -707,13 +705,13 @@ class ZSR:
                     "default": "off",
                     "options": {
                         "off": {
-                            "name": "On",
+                            "name": "Off",
                             "data": {
                                 "plant_beans": False
                             }
                         },
                         "on": {
-                            "name": "Off",
+                            "name": "On",
                             "data": {
                                 "plant_beans": True
                             }
@@ -757,4 +755,4 @@ class ZSR:
                     }
                 }
             }
-}
+        }

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -102,7 +102,7 @@ class ZSR:
             return latest_dev_version, True
         return latest_dev_version, False
 
-    def roll_seed(self, preset, encrypt, dev, settings):
+    def roll_seed(self, preset, encrypt, dev, settings=None):
         """
         Generate a seed and return its public URL.
         """

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -174,7 +174,7 @@ class ZSR:
         return {
             "major": {
                 "bridge": {
-                    "__setting": "Rainbow Bridge",
+                    "_setting": "Rainbow Bridge",
                     "default": "meds",
                     "options": {
                         "meds": {
@@ -193,7 +193,7 @@ class ZSR:
                     }
                 },
                 "deku": {
-                    "__setting": "Deku",
+                    "_setting": "Deku",
                     "default": "closed",
                     "options": {
                         "closed": {
@@ -211,7 +211,7 @@ class ZSR:
                     }
                 },
                 "interiors": {
-                    "__setting": "Interior ER",
+                    "_setting": "Interior ER",
                     "default": "off",
                     "options": {
                         "off": {
@@ -229,7 +229,7 @@ class ZSR:
                     }
                 },
                 "dungeons": {
-                    "__setting": "Dungeon ER",
+                    "_setting": "Dungeon ER",
                     "default": "off",
                     "options": {
                         "off": {
@@ -239,7 +239,7 @@ class ZSR:
                             }                    
                         },
                         "on": {
-                            "name": "Simple (excl. Ganon's Castle)",
+                            "name": "On (excl. Ganon's Castle)",
                             "data": {
                                 "shuffle_dungeon_entrances": "simple"
                             }
@@ -247,7 +247,7 @@ class ZSR:
                     }
                 },
                 "grottos": {
-                    "__setting": "Grotto ER",
+                    "_setting": "Grotto ER",
                     "default": "off",
                     "options": {
                         "off": {
@@ -265,7 +265,7 @@ class ZSR:
                     }
                 },
                 "shops": {
-                    "__setting": "Shopsanity",
+                    "_setting": "Shopsanity",
                     "default": "off",
                     "options": {
                         "off": {
@@ -283,7 +283,7 @@ class ZSR:
                     }
                 },
                 "ow_tokens": {
-                    "__setting": "Overworld Token Shuffle",
+                    "_setting": "Overworld Token Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -301,7 +301,7 @@ class ZSR:
                     }
                 },
                 "dungeon_tokens": {
-                    "__setting": "Dungeon Token Shuffle",
+                    "_setting": "Dungeon Token Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -319,7 +319,7 @@ class ZSR:
                     }
                 },
                 "scrubs": {
-                    "__setting": "Scrub Shuffle",
+                    "_setting": "Scrub Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -337,7 +337,7 @@ class ZSR:
                     }
                 },
                 "keys": {
-                    "__setting": "Key Shuffle",
+                    "_setting": "Key Shuffle",
                     "default": "own_dungeon",
                     "options": {
                         "own_dungeon": {
@@ -365,7 +365,7 @@ class ZSR:
                     }
                 },
                 "required_only": {
-                    "__setting": "Required Only (Beatable Only)",
+                    "_setting": "Required Only (Beatable Only)",
                     "default": "off",
                     "options": {
                         "off": {
@@ -383,7 +383,7 @@ class ZSR:
                     }
                 },
                 "zora_fountain": {
-                    "__setting": "Zora Fountain",
+                    "_setting": "Zora Fountain",
                     "default": "closed",
                     "options": {
                         "closed": {
@@ -401,7 +401,7 @@ class ZSR:
                     }
                 },
                 "cows": {
-                    "__setting": "Cow Shuffle",
+                    "_setting": "Cow Shuffle",
                     "default": "off",
                     "options": {
                         "off": {
@@ -419,7 +419,7 @@ class ZSR:
                     }
                 },
                 "gerudo_card": {
-                    "__setting": "Shuffled Gerudo Card",
+                    "_setting": "Shuffled Gerudo Card",
                     "default": "off",
                     "options": {
                         "off": {
@@ -437,7 +437,7 @@ class ZSR:
                     }
                 },
                 "trials": {
-                    "__setting": "Trials",
+                    "_setting": "Trials",
                     "default": "off",
                     "options": {
                         "off": {
@@ -457,7 +457,7 @@ class ZSR:
             },
             "minor": {
                 "starting_age": {
-                    "__setting": "Starting Age",
+                    "_setting": "Starting Age",
                     "default": "random",
                     "options": {
                         "random": {
@@ -481,7 +481,7 @@ class ZSR:
                     }
                 },
                 "random_spawns": {
-                    "__setting": "Random Spawns",
+                    "_setting": "Random Spawns",
                     "default": "off",
                     "options": {
                         "off": {
@@ -502,7 +502,7 @@ class ZSR:
                     }
                 },
                 "consumables": {
-                    "__setting": "Start with Consumables",
+                    "_setting": "Start with Consumables",
                     "default": "on",
                     "options": {
                         "on": {
@@ -520,7 +520,7 @@ class ZSR:
                     }
                 },
                 "rupees": {
-                    "__setting": "Start with Max Rupees",
+                    "_setting": "Start with Max Rupees",
                     "default": "off",
                     "options": {
                         "off": {
@@ -538,7 +538,7 @@ class ZSR:
                     }
                 },
                 "cuccos": {
-                    "__setting": "Anju's Chicken Count",
+                    "_setting": "Anju's Chicken Count",
                     "default": "7",
                     "options": {
                         "7": {
@@ -556,7 +556,7 @@ class ZSR:
                     }
                 },
                 "free_scarecrow": {
-                    "__setting": "Free Scarecrow",
+                    "_setting": "Free Scarecrow",
                     "default": "off",
                     "options": {
                         "off": {
@@ -574,7 +574,7 @@ class ZSR:
                     }
                 },
                 "camc": {
-                    "__setting": "Chest Appearance Matches Contents",
+                    "_setting": "CAMC",
                     "default": "on",
                     "options": {
                         "on": {
@@ -592,7 +592,7 @@ class ZSR:
                     }
                 },
                 "mask_quest": {
-                    "__setting": "Completed Mask Quest",
+                    "_setting": "Completed Mask Quest",
                     "default": "off",
                     "options": {
                         "off": {
@@ -611,7 +611,7 @@ class ZSR:
                     }
                 },
                 "bfa": {
-                    "__setting": "Blue Fire Arrows",
+                    "_setting": "Blue Fire Arrows",
                     "default": "off",
                     "options": {
                         "off": {
@@ -629,7 +629,7 @@ class ZSR:
                     }
                 },
                 "owls": {
-                    "__setting": "Random Owl Drops",
+                    "_setting": "Random Owl Drops",
                     "default": "off",
                     "options": {
                         "off": {
@@ -647,7 +647,7 @@ class ZSR:
                     }
                 },
                 "song_warps": {
-                    "__setting": "Random Song Warps",
+                    "_setting": "Random Song Warps",
                     "default": "off",
                     "options": {
                         "off": {
@@ -665,7 +665,7 @@ class ZSR:
                     }
                 },
                 "shuffle_beans": {
-                    "__setting": "Shuffled Magic Beans",
+                    "_setting": "Shuffled Magic Beans",
                     "default": "off",
                     "options": {
                         "off": {
@@ -683,7 +683,7 @@ class ZSR:
                     }
                 },
                 "expensive_merchants": {
-                    "__setting": "Expensive Merchants",
+                    "_setting": "Expensive Merchants",
                     "default": "off",
                     "options": {
                         "off": {
@@ -701,7 +701,7 @@ class ZSR:
                     }
                 },
                 "beans_planted": {
-                    "__setting": "Magic Beans Planted",
+                    "_setting": "Magic Beans Planted",
                     "default": "off",
                     "options": {
                         "off": {
@@ -719,7 +719,7 @@ class ZSR:
                     }
                 },
                 "door_of_time": {
-                    "__setting": "Door of Time",
+                    "_setting": "Door of Time",
                     "default": "open",
                     "options": {
                         "open": {
@@ -737,7 +737,7 @@ class ZSR:
                     }
                 },
                 "chus_in_logic": {
-                    "__setting": "Bombchus in Logic",
+                    "_setting": "Bombchus in Logic",
                     "default": "off",
                     "options": {
                         "off": {

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -171,5 +171,590 @@ class ZSR:
         """
         Settings pool for Draft Mode.
         """
-        pool = requests.get(self.draft_settings_pool_endpoint).json()
-        return pool
+        # pool = requests.get(self.draft_settings_pool_endpoint).json()
+        # return pool
+        return {
+            "major": {
+                "bridge": {
+                    "__setting": "Rainbow Bridge",
+                    "default": "meds",
+                    "options": {
+                        "meds": {
+                            "name": "6 meds, No GCBK",
+                            "data": {
+                                "bridge": "medallions"   
+                            }
+                        },
+                        "open": {
+                            "name": "Open, 6 med GCBK",
+                            "data": {
+                                "bridge": "medallions",
+                                "shuffle_ganon_bosskey": "medallions"
+                            }
+                        }
+                    }
+                },
+                "deku": {
+                    "__setting": "Deku",
+                    "default": "closed",
+                    "options": {
+                        "closed": {
+                            "name": "Closed",
+                            "data": {
+                                "open_forest": "closed_deku"
+                            }
+                        },
+                        "open": {
+                            "name": "Open",
+                            "data": {
+                                "open_forest": "open"
+                            }
+                        }
+                    }
+                },
+                "interiors": {
+                    "__setting": "Interior ER",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_interior_entrances": "off"
+                            }
+                        },
+                        "on": {
+                            "name": "On (all interiors)",
+                            "data": {
+                                "shuffle_interior_entrances": "all"
+                            }
+                        }
+                    }
+                },
+                "dungeons": {
+                    "__setting": "Dungeon ER",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_dungeon_entrances": "off"
+                            }                    
+                        },
+                        "on": {
+                            "name": "Simple (excl. Ganon's Castle)",
+                            "data": {
+                                "shuffle_dungeon_entrances": "simple"
+                            }
+                        }
+                    }
+                },
+                "grottos": {
+                    "__setting": "Grotto ER",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_grotto_entrances": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "shuffle_grotto_entrances": True
+                            }
+                        }
+                    }
+                },
+                "shops": {
+                    "__setting": "Shopsanity",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shopsanity": "off"
+                            }
+                        },
+                        "on": {
+                            "name": "On (4)",
+                            "data": {
+                                "shopsanity": "4"
+                            }
+                        }
+                    }
+                },
+                "ow_tokens": {
+                    "__setting": "Overworld Tokens",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "tokensanity": "off"
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "tokensanity": "overworld"
+                            }
+                        }
+                    }
+                },
+                "dungeon_tokens": {
+                    "__setting": "Dungeon Tokens",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "tokensanity": "off"
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "tokensanity": "dungeons"
+                            }
+                        }
+                    }
+                },
+                "scrubs": {
+                    "__setting": "Scrub Shuffle",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_scrubs": "off"
+                            }
+                        },
+                        "on": {
+                            "name": "On (affordable)",
+                            "data": {
+                                "shuffle_scrubs": "low"
+                            }
+                        }
+                    }
+                },
+                "keys": {
+                    "__setting": "Key Shuffle",
+                    "default": "own_dungeon",
+                    "options": {
+                        "own_dungeon": {
+                            "name": "Own Dungeon",
+                            "data": {
+                                "shuffle_smallkeys": "dungeon",
+                                "shuffle_bosskeys": "dungeon"
+                            }
+                        },
+                        "keysy": {
+                            "name": "Keysy (inc. BK)",
+                            "data": {
+                                "shuffle_smallkeys": "remove",
+                                "shuffle_bosskeys": "remove"
+                            }
+                        },
+                        "anywhere": {
+                            "name": "Keyrings Anywhere (inc. BK)",
+                            "data": {
+                                "shuffle_smallkeys": "keysanity",
+                                "key_rings_choice": "all",
+                                "keyring_give_bk": True
+                            }
+                        }
+                    }
+                },
+                "required_only": {
+                    "__setting": "Required Only (Beatable Only)",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "reachable_locations": "all"
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "reachable_locations": "beatable"
+                            }
+                        }
+                    }
+                },
+                "zora_fountain": {
+                    "__setting": "Zora Fountain",
+                    "default": "closed",
+                    "options": {
+                        "closed": {
+                            "name": "Closed",
+                            "data": {
+                                "zora_fountain": "closed"
+                            }
+                        },
+                        "open": {
+                            "name": "Open",
+                            "data": {
+                                "zora_fountain": "open"
+                            }
+                        }
+                    }
+                },
+                "cows": {
+                    "__setting": "Cow Shuffle",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_cows": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "shuffle_cows": True
+                            }
+                        }
+                    }
+                },
+                "gerudo_card": {
+                    "__setting": "Shuffled Gerudo Card",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_gerudo_card": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "shuffle_gerudo_card": True
+                            }
+                        }
+                    }
+                },
+                "trials": {
+                    "__setting": "Trials",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "trials": 0
+                            }
+                        },
+                        "on": {
+                            "name": "On (3 random)",
+                            "data": {
+                                "trials": 3
+                            }
+                        }
+                    }
+                }
+            },
+            "minor": {
+                "starting_age": {
+                    "__setting": "Starting Age",
+                    "default": "random",
+                    "options": {
+                        "random": {
+                            "name": "Random",
+                            "data": {
+                                "starting_age": "random"
+                            }
+                        },
+                        "child": {
+                            "name": "Child",
+                            "data": {
+                                "starting_age": "child"   
+                            }
+                        },
+                        "adult": {
+                            "name": "Adult",
+                            "data": {
+                                "starting_age": "adult"
+                            }
+                        }
+                    }
+                },
+                "random_spawns": {
+                    "__setting": "Random Spawns",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "spawn_positions": []
+                            }
+                        },
+                        "on": {
+                            "name": "On (both)",
+                            "data": {
+                                "spawn_positions": [
+                                    "child",
+                                    "adult"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "consumables": {
+                    "__setting": "Start with Consumables",
+                    "default": "on",
+                    "options": {
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "start_with_consumables": True
+                            }
+                        },
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "start_with_consumables": False
+                            }
+                        }
+                    }
+                },
+                "rupees": {
+                    "__setting": "Start with Rupees",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "start_with_rupees": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "start_with_rupees": True
+                            }
+                        }
+                    }
+                },
+                "cuccos": {
+                    "__setting": "Chicken Count",
+                    "default": "7",
+                    "options": {
+                        "7": {
+                            "name": "7",
+                            "data": {
+                                "chicken_count": 7
+                            }
+                        },
+                        "1": {
+                            "name": "1",
+                            "data": {
+                                "chicken_count": 1
+                            }
+                        }
+                    }
+                },
+                "free_scarecrow": {
+                    "__setting": "Free Scarecrow",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "free_scarecrow": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "free_scarecrow": True
+                            }
+                        }
+                    }
+                },
+                "camc": {
+                    "__setting": "Chest Appearance Matches Contents",
+                    "default": "on",
+                    "options": {
+                        "on": {
+                            "name": "On (Size and Texture)",
+                            "data": {
+                                "correct_chest_appearances": "both"
+                            }
+                        },
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "correct_chest_appearances": "off"   
+                            }
+                        }
+                    }
+                },
+                "mask_quest": {
+                    "__setting": "Completed Mask Quest",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "complete_mask_quest": False
+                            }
+                        },
+                        "on": {
+                            "name": "On (w/ slow Bunny Hood)",
+                            "data": {
+                                "complete_mask_quest": True,
+                                "fast_bunny_hood": False
+                            }
+                        }
+                    }
+                },
+                "bfa": {
+                    "__setting": "Blue Fire Arrows",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "blue_fire_arrows": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "blue_fire_arrows": True
+                            }
+                        }
+                    }
+                },
+                "owls": {
+                    "__setting": "Random Owl Drops",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "owl_drops": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "owl_drops": True
+                            }
+                        }
+                    }
+                },
+                "song_warps": {
+                    "__setting": "Random Song Warps",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "warp_songs": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "warp_songs": True
+                            }
+                        }
+                    }
+                },
+                "shuffle_beans": {
+                    "__setting": "Shuffled Magic Beans",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_beans": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "shuffle_beans": True
+                            }
+                        }
+                    }
+                },
+                "expensive_merchants": {
+                    "__setting": "Expensive Merchants",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "shuffle_expensive_merchants": False
+                            }
+                        },
+                        "on": {
+                            "name": "On",
+                            "data": {
+                                "shuffle_expensive_merchants": True
+                            }
+                        }
+                    }
+                },
+                "beans_planted": {
+                    "__setting": "Planted Magic Beans",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "On",
+                            "data": {
+                                "plant_beans": False
+                            }
+                        },
+                        "on": {
+                            "name": "Off",
+                            "data": {
+                                "plant_beans": True
+                            }
+                        }
+                    }
+                },
+                "door_of_time": {
+                    "__setting": "Door of Time",
+                    "default": "open",
+                    "options": {
+                        "open": {
+                            "name": "Open",
+                            "data": {
+                                "open_door_of_time": True
+                            }
+                        },
+                        "closed": {
+                            "name": "Closed",
+                            "data": {
+                                "open_door_of_time": False
+                            }
+                        }
+                    }
+                },
+                "chus_in_logic": {
+                    "__setting": "Bombchus in Logic",
+                    "default": "off",
+                    "options": {
+                        "off": {
+                            "name": "Off",
+                            "data": {
+                                "free_bombchu_drops": False
+                            }
+                        },
+                        "on": {
+                            "name": "On (adds Bombchu Bag)",
+                            "data": {
+                                "free_bombchu_drops": True
+                            }
+                        }
+                    }
+                }
+            }
+}


### PR DESCRIPTION
This PR aims to allow draft races to be configurable through the use of message actions. I'm also attempting to move the majority of the draft code out of `handler.py` and into it's own module with the use of a parent class and different sub-classes depending on the race type.

### To Do:
- [x] Configurable Settings
- [x] Auto-select settings system
- [ ] Pick/ban system
- [ ] Post picks/bans to remote for statistics

Naming conventions and buttons inspired by #17 (thank you @tobiasgies 😄)