### PR TITLE
Point preset functions to aliases in settings json

### DIFF
--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -68,12 +68,12 @@ class ZSR:
         presets = requests.get(self.preset_endpoint).json()
         settings = requests.get(self.settings_endpoint).json()
         return {
-            preset: {
-                'full_name': setting,
-                'settings': settings.get(setting)
+            key: {
+                'full_name': value['fullName'],
+                'settings': settings.get(value['fullName']),
             }
-            for preset in presets for setting in settings
-            if preset in settings[setting]['aliases']
+            for key, value in presets.items()
+            if value['fullName'] in settings
         }
 
     def load_presets_dev(self):

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -68,12 +68,12 @@ class ZSR:
         presets = requests.get(self.preset_endpoint).json()
         settings = requests.get(self.settings_endpoint).json()
         return {
-            key: {
-                'full_name': value['fullName'],
-                'settings': settings.get(value['fullName']),
+            preset: {
+                'full_name': setting,
+                'settings': settings.get(setting)
             }
-            for key, value in presets.items()
-            if value['fullName'] in settings
+            for preset in presets for setting in settings
+            if preset in settings[setting]['aliases']
         }
 
     def load_presets_dev(self):
@@ -83,12 +83,12 @@ class ZSR:
         presets_dev = requests.get(self.preset_dev_endpoint).json()
         settings_dev = requests.get(self.settings_dev_endpoint).json()
         return {
-            key: {
-                'full_name': value['fullName'],
-                'settings': settings_dev.get(value['fullName']),
+            preset: {
+                'full_name': setting,
+                'settings': settings_dev.get(setting)
             }
-            for key, value in presets_dev.items()
-            if value['fullName'] in settings_dev
+            for preset in presets_dev for setting in settings_dev
+            if preset in settings_dev[setting]['aliases']
         }
 
     def get_latest_dev_version(self):

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -80,17 +80,15 @@ class ZSR:
         """
         Load and return available seed presets for dev.
         """
-        presets_dev = requests.get(self.preset_dev_endpoint).json()
         settings_dev = requests.get(self.settings_dev_endpoint).json()
         return {
-            preset: {
-                'full_name': setting,
-                'settings': settings_dev.get(setting)
+            min(settings_dev[preset]['aliases'], key=len): {
+                'full_name': preset,
+                'settings': settings_dev.get(preset)
             }
-            for preset in presets_dev for setting in settings_dev
-            if preset in settings_dev[setting]['aliases']
+            for preset in settings_dev
         }
-
+        
     def get_latest_dev_version(self):
         """
         Returns currently active dev version and a bool indicating if it's changed.

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -88,7 +88,7 @@ class ZSR:
             }
             for preset in settings_dev
         }
-        
+
     def get_latest_dev_version(self):
         """
         Returns currently active dev version and a bool indicating if it's changed.


### PR DESCRIPTION
Currently waiting on https://github.com/OoTRandomizer/OoT-Randomizer/pull/2175 to be merged before this is relevant.

This changes the way presets are loaded so we don't have to constantly update the preset name manually whenever a change is made, ex. League S5 -> League S6, etc. The presets will populate based on a check for a static alias within each settings dict and return the appropriate name plus any settings changes.