### PR TITLE
Ignore rooms opened by bots

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -78,16 +78,18 @@ class RandoHandler(RaceHandler):
         self.midos_house = midos_house
 
     async def should_stop(self):
+        if self.data.get('opened_by') is None:
+            # Ignore all rooms opened by bots, allowing Mido (https://github.com/midoshouse/midos.house) to open rooms in official goals.
+            # This is okay because RandoBot does not open any rooms.
+            return True
         goal_name = self.data.get('goal', {}).get('name')
         goal_is_custom = self.data.get('goal', {}).get('custom', False)
         if goal_is_custom:
             if await self.midos_house.handles_custom_goal(goal_name):
-                return True # handled by Mido (https://github.com/midoshouse/midos.house)
+                return True # handled by Mido
         else:
-            if goal_name == 'Random settings league':
-                return True # handled by RSLBot (https://github.com/midoshouse/midos.house)
-            elif goal_name == 'Triforce Blitz':
-                return True # handled by Mido (https://github.com/midoshouse/midos.house)
+            if goal_name in ('Random settings league', 'Triforce Blitz'):
+                return True # handled by Mido
         return await super().should_stop()
 
     async def begin(self):


### PR DESCRIPTION
Ignore all rooms opened by bots, allowing Mido to open rooms in official goals.

The S7 Challenge Cup organizers have forwarded feedback from some entrants who would prefer to have official CC races affect their Standard Ruleset score. I still need to discuss the change with the OoTR category mods, but this PR would allow it to happen in case it's approved, and even if it isn't, it doesn't break anything because RandoBot doesn't open any rooms and there are no other bots in the OoTR category besides RandoBot and Mido.

This PR also updates a comment to reflect the fact that my bot now uses the Mido username even in RSL races.