### PR TITLE
feat: add workflow to roll a seed with a password hash

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -86,6 +86,10 @@ ocarina notes. This password is required to start a file in the generated seed.
 Once this setting is enabled, Randobot will publish the password at the start of the
 race countdown next to the seed hash in the race room information.
 
+If the automated password acquiry after rolling the seed fails multiple times, manual acquiry 
+can be attempted using `!password get`. Note that a race with a password activated seed can 
+not be started without a password.
+
 
 ## !s7
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -81,7 +81,7 @@ can be toggled on by a race monitor or moderator with `!password on`.
 It can be toggled off again with `!password off`.
 
 When enabled, the seed is generated with a random 5 digit password consisting of
-ocarina notes. This password is required to be start a file in the generated seed.
+ocarina notes. This password is required to start a file in the generated seed.
 
 Once this setting is enabled, Randobot will publish the password at the start of the
 race countdown next to the seed hash in the race room information.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -86,9 +86,8 @@ ocarina notes. This password is required to start a file in the generated seed.
 Once this setting is enabled, Randobot will publish the password at the start of the
 race countdown next to the seed hash in the race room information.
 
-If the automated password acquiry after rolling the seed fails multiple times, manual acquiry 
-can be attempted using `!password get`. Note that a race with a password activated seed can 
-not be started without a password.
+If the automated password retrieval after rolling the seed, manual acquiry can be attempted using `!password get`. 
+Note that a race with a password activated seed can not be started without a password.
 
 
 ## !s7

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -71,6 +71,22 @@ immediately if there is a ping.
 To prevent spam or misuse, it is also recommended that the **"Allow non-entrant
 chat"** race setting is disabled when conducting a race using FPA.
 
+
+## !password
+
+Usable by: **varies**
+
+Enable or disable the password functionality. By default, this is disabled, but it 
+can be toggled on by a race monitor or moderator with `!password on`. 
+It can be toggled off again with `!password off`.
+
+When enabled, the seed is generated with a random 5 digit password consisting of
+ocarina notes. This password is required to be start a file in the generated seed.
+
+Once this setting is enabled, Randobot will publish the password at the start of the
+race countdown next to the seed hash in the race room information.
+
+
 ## !s7
 
 Usable by: **race monitor/room opener**

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -105,7 +105,7 @@ class RandoHandler(RaceHandler):
                     msg_actions.Action(
                         label='Roll seed',
                         help_text='Create a seed using the latest release',
-                        message='!seed ${preset} ${--withpassword}',
+                        message='!seed ${preset} ',
                         submit='Roll race seed',
                         survey=msg_actions.Survey(
                             msg_actions.SelectInput(
@@ -114,17 +114,12 @@ class RandoHandler(RaceHandler):
                                 options={key: value['full_name'] for key, value in self.zsr.presets.items()},
                                 default='weekly',
                             ),
-                            msg_actions.BoolInput(
-                                name='--withpassword',
-                                label='Password',
-                                help_text='Locks file creation behind a 5 ocarina notes password provided at countdown start',
-                            ),
                         ),
                     ),
                     msg_actions.Action(
                         label='Dev seed',
                         help_text='Create a seed using the latest dev branch',
-                        message='!seeddev ${preset}',
+                        message='!seeddev ${preset} ${--withpassword}',
                         submit='Roll dev seed',
                         survey=msg_actions.Survey(
                             msg_actions.SelectInput(

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -180,11 +180,11 @@ class RandoHandler(RaceHandler):
                 'seed_hash': self.state['seed_hash'],
                 'seed_url': self.seed_url % self.state['seed_id'],
             })
-            resp = (
-                'This seed is password protected. To start a file, enter this password on the file select screen:\n'
-                '%{seed_password}\nYou are allowed to enter the password before the race starts.'
-            )
-            await self.send_message(resp)
+            await self.send_message(
+                    'This seed is password protected. To start a file, enter this password on the file select screen:\n'
+                    '%(seed_password)s\nYou are allowed to enter the password before the race starts.'
+                    % {'seed_password': seed_password}
+                )
             self.state['password_published'] = True
         if self._race_in_progress() and self.state.get('pinned_msg'):
             await self.unpin_message(self.state['pinned_msg'])

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -890,12 +890,12 @@ class RandoHandler(RaceHandler):
         if len(args) > 0:
             preset = args[0]
             
-            if len(args) == 2 and args[1] == "withpassword":
+            if len(args) == 2 and args[1] == "--withpassword":
                 self.state['password_active'] = True
             else: 
                 await self.send_message(
                     'Sorry %(reply_to)s, that is not the correct syntax. '
-                    'The syntax is "!seed presetName {withpassword}'
+                    'The syntax is "!seed presetName {--withpassword}'
                     % {'reply_to': reply_to or 'friend'}
                 )
                 return

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -180,7 +180,7 @@ class RandoHandler(RaceHandler):
             self.state['password_published'] = True
         if self._race_in_progress() and self.state.get('pinned_msg'):
             await self.unpin_message(self.state['pinned_msg'])
-            del self.state['pinned_msg']  
+            del self.state['pinned_msg']
 
     @monitor_cmd
     async def ex_s7(self, args, message):

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -105,7 +105,7 @@ class RandoHandler(RaceHandler):
                     msg_actions.Action(
                         label='Roll seed',
                         help_text='Create a seed using the latest release',
-                        message='!seed ${preset} ',
+                        message='!seed ${preset}',
                         submit='Roll race seed',
                         survey=msg_actions.Survey(
                             msg_actions.SelectInput(

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -179,16 +179,15 @@ class RandoHandler(RaceHandler):
     async def race_data(self, data):
         await super().race_data(data)
         if self._race_pending() and self.state.get('password_active') and not self.state['password_published']:
-            seed_password = self.state['seed_password']
-            await self.set_bot_raceinfo('File Select Password: %{seed_password} -- Hash: %(seed_hash)s\n%(seed_url)s' % {
-                'seed_password': seed_password,
+            await self.set_bot_raceinfo('%(seed_hash)s | Password: %(seed_password)s\n%(seed_url)s' % {
+                'seed_password': self.state['seed_password'],
                 'seed_hash': self.state['seed_hash'],
                 'seed_url': self.seed_url % self.state['seed_id'],
             })
             await self.send_message(
                     'This seed is password protected. To start a file, enter this password on the file select screen:\n'
                     '%(seed_password)s\nYou are allowed to enter the password before the race starts.'
-                    % {'seed_password': seed_password}
+                    % {'seed_password': self.state['seed_password']}
                 )
             self.state['password_published'] = True
         if self._race_in_progress() and self.state.get('pinned_msg'):

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -1011,7 +1011,7 @@ class RandoHandler(RaceHandler):
                 await self.load_seed_password()
         else:
             self.state['seed_password'] = seed_password
-            if (manual):
+            if manual:
                 return True
 
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -133,6 +133,11 @@ class RandoHandler(RaceHandler):
                                 options={key: value['full_name'] for key, value in self.zsr.presets_dev.items()},
                                 default='weekly',
                             ),
+                            msg_actions.BoolInput(
+                                name='--withpassword',
+                                label='Password',
+                                help_text='Locks file creation behind a 5 ocarina notes password provided at countdown start',
+                            ),
                         ),
                     ),
                     msg_actions.ActionLink(

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -206,7 +206,7 @@ class ZSR:
                     self.notes_map.get(item, item)
                     for item in password_notes
                 )
-            except (ValueError, requests.RequestException) as e:
+            except (ValueError, requests.RequestException):
                 if attempt < retries - 1:
                     time.sleep(delay)
                 else:

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -11,6 +11,7 @@ class ZSR:
     seed_endpoint = 'https://ootrandomizer.com/api/v2/seed/create'
     status_endpoint = 'https://ootrandomizer.com/api/v2/seed/status'
     details_endpoint = 'https://ootrandomizer.com/api/v2/seed/details'
+    password_endpoint = 'https://ootrandomizer.com/api/v2/seed/pw'
     version_endpoint = 'https://ootrandomizer.com/api/version'
     preset_endpoint = 'https://ootrandomizer.com/rtgg/ootr_presets.json'
     preset_dev_endpoint = 'https://ootrandomizer.com/rtgg/ootr_presets_dev.json'
@@ -52,6 +53,14 @@ class ZSR:
         'Slingshot': 'HashSlingshot',
         'SOLD OUT': 'HashSoldOut',
         'Stone of Agony': 'HashStoneOfAgony',
+    }
+
+    notes_map = {
+        'A': 'NoteA',
+        'C down':'NoteCdown',
+        'C up':'NoteCup',
+        'C left':'NoteCleft',
+        'C right':'NoteCright',
     }
 
     def __init__(self, ootr_api_key):
@@ -100,7 +109,7 @@ class ZSR:
             return latest_dev_version, True
         return latest_dev_version, False
 
-    def roll_seed(self, preset, encrypt, dev, settings, race_type):
+    def roll_seed(self, preset, encrypt, dev, settings, race_type, password=False):
         """
         Generate a seed and return its public URL.
         """
@@ -129,6 +138,8 @@ class ZSR:
             params['encrypt'] = 'true'
         if encrypt and dev:
             params['locked'] = 'true'
+        if password and not dev:
+            params['passwordLock'] = 'true'
         if race_type == 'qualifier':
             params['hideSettings'] = 'true'
         if dev:
@@ -171,3 +182,20 @@ class ZSR:
         """
         pool = requests.get(self.draft_settings_pool_endpoint).json()
         return pool
+    
+    def get_password(self, seed_id):
+        """
+        Grab password for seed with active password
+        """
+        data = requests.get(self.password_endpoint, params={
+            'id': seed_id,
+            'key': self.ootr_api_key,
+        }).json()
+        try:
+            password_notes = json.loads(data.get('pw'))
+        except ValueError:
+            return None
+        return ' '.join(
+            self.notes_map.get(item, item)
+            for item in password_notes
+        )

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -138,7 +138,7 @@ class ZSR:
             params['encrypt'] = 'true'
         if encrypt and dev:
             params['locked'] = 'true'
-        if password :
+        if password:
             params['passwordLock'] = 'true'
         if race_type == 'qualifier':
             params['hideSettings'] = 'true'

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -138,7 +138,7 @@ class ZSR:
             params['encrypt'] = 'true'
         if encrypt and dev:
             params['locked'] = 'true'
-        if password and not dev:
+        if password :
             params['passwordLock'] = 'true'
         if race_type == 'qualifier':
             params['hideSettings'] = 'true'


### PR DESCRIPTION
Password will be generated for release seeds if the chat command is used or the checkbox in the dialog is checked.

Password will be added to race info through emotes once the timer starts.