### PR TITLE
Add Support For Rolling Seeds From Different Dev Branches

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -2,15 +2,26 @@
 
 These are the commands currently supported by OoTR's RandoBot.
 
+## !branch
+
+Usable by: anyone (unless seed is already rolled)
+
+Select which ootrandomizer.com branch to use when rolling a seed, whether it be
+the stable (release) branch or one of a development branches.
+
+Once a seed has been generated using `!seed` (or `!spoilerseed`), subsequent
+calls to `!branch` will not work unless used by a moderator.
+
 ## !seed
 
 Usable by: anyone (unless lock is present)
 
-Roll a race seed on ootrandomizer.com using the specified preset (if given) and
+If `!branch` has not been set, this command will do nothing.
+
+Roll a seed on ootrandomizer.com using the specified preset and
 post a link to the generated seed in the race information.
 
-Available presets can be checked using the `!presets` command. If no preset is
-given then "weekly" is assumed.
+Available presets can be checked using the `!presets` command.
 
 If seed rolling has been locked with the `!lock` command then `!seed` will not
 generate a seed unless it's used by a race monitor or moderator.
@@ -22,7 +33,7 @@ calls to `!seed` will not work unless used by a moderator.
 
 Usable by: anyone (unless lock is present)
 
-Roll a non-race seed (i.e. seed with spoiler log). This is identical to
+Roll a seed with a spoiler log. This is identical to
 `!seed`, except for the addition of the spoiler log. The patch file will also
 not be encrypted.
 
@@ -30,8 +41,10 @@ not be encrypted.
 
 Usable by: anyone
 
-The bot will print out a list of available presets for use with the `!seed` or
-`!spoilerseed` commands. Each preset is usually a single word, e.g. "s4" or
+If `!branch` has not been set, this command will do nothing.
+
+The bot will print out a list of available presets from currently selected branch for use with the `!seed` or
+`!spoilerseed` commands. Each preset is usually a single word, e.g. "s9" or
 "weekly".
 
 Presets are set by ootrandomizer.com and are not controlled by the bot itself.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -43,7 +43,7 @@ Usable by: anyone
 
 If `!branch` has not been set, this command will do nothing.
 
-The bot will print out a list of available presets from currently selected branch for use with the `!seed` or
+The bot will print out a list of available presets from the currently selected branch for use with the `!seed` or
 `!spoilerseed` commands. Each preset is usually a single word, e.g. "s9" or
 "weekly".
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,21 +4,19 @@ These are the commands currently supported by OoTR's RandoBot.
 
 ## !branch
 
-Usable by: anyone (unless seed is already rolled)
+Usable by: **race monitor/moderators/room opener only** (unless seed is already rolled)
 
 Select which ootrandomizer.com branch to use when rolling a seed, whether it be
 the stable (release) branch or one of a development branches.
 
 Once a seed has been generated using `!seed` (or `!spoilerseed`), subsequent
-calls to `!branch` will not work unless used by a moderator.
+calls to `!branch` will not work unless used by a race moderator.
 
 ## !seed
 
 Usable by: anyone (unless lock is present)
 
-If `!branch` has not been set, this command will do nothing.
-
-Roll a seed on ootrandomizer.com using the specified preset and
+Roll a seed on ootrandomizer.com using the specified preset (if given, otherwise defaults to 'weekly') and
 post a link to the generated seed in the race information.
 
 Available presets can be checked using the `!presets` command.
@@ -40,8 +38,6 @@ not be encrypted.
 ## !presets
 
 Usable by: anyone
-
-If `!branch` has not been set, this command will do nothing.
 
 The bot will print out a list of available presets from the currently selected branch for use with the `!seed` or
 `!spoilerseed` commands. Each preset is usually a single word, e.g. "s9" or

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -160,7 +160,7 @@ class RandoHandler(RaceHandler):
     async def end(self):
         if self.state.get('pinned_msg'):
             await self.unpin_message(self.state['pinned_msg'])
-            
+
     async def chat_message(self, data):
         message = data.get('message', {})
         if (

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -448,7 +448,7 @@ class RandoHandler(RaceHandler):
             )
             return
 
-        seed_id, seed_uri = self.zsr.roll_seed(preset, encrypt, branch, password)
+        seed_id, seed_uri = self.zsr.roll_seed(preset, branch, encrypt, password)
 
         await self.send_message(
             '%(reply_to)s, here is your seed: %(seed_uri)s'

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -389,6 +389,13 @@ class RandoHandler(RaceHandler):
         """
         reply_to = message.get('user', {}).get('name')
 
+        if len(args) == 0:
+            await self.send_message(
+                'Sorry %(reply_to)s, that is not the correct syntax. '
+                'The syntax is "!seed presetName {--withpassword}'
+                % {'reply_to': reply_to or 'friend'}
+            )
+            return
         if len(args) > 0:
             preset = args[0]
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -477,7 +477,7 @@ class RandoHandler(RaceHandler):
                 await self.load_seed_hash()
                 if self.state.get('password_active'):
                     await self.load_seed_password()
-                    return
+                return
             elif status >= 2:
                 break
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -123,7 +123,7 @@ class RandoHandler(RaceHandler):
                         ),
                     ),
                     msg_actions.Action(
-                        label=' Change Branch',
+                        label='Change Branch',
                         help_text='Change the branch to use when rolling the seed.',
                         message='!branch ${branch}',
                         submit='Select',

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -64,7 +64,7 @@ class RandoHandler(RaceHandler):
     """
     seed_url = 'https://ootrandomizer.com/seed/get?id=%s'
     stop_at = ['cancelled', 'finished']
-    max_status_checks = 50
+    max_status_checks = 90
     greetings = (
         'Let me roll a seed for you. I promise it won\'t hurt.',
         'It\'s dangerous to go alone. Take this?',
@@ -467,12 +467,19 @@ class RandoHandler(RaceHandler):
         await self.check_seed_status()
 
     async def check_seed_status(self):
-        await sleep(1)
+        await sleep(2)
         status = self.zsr.get_status(self.state['seed_id'])
+
         if status == 0:
             self.state['status_checks'] += 1
             if self.state['status_checks'] < self.max_status_checks:
                 await self.check_seed_status()
+            else:
+                self.state['seed_id'] = None
+                await self.send_message(
+                'Sorry, but it looks like the seed failed to generate. Use '
+                '!seed to try again.'
+            )
         elif status == 1:
             await self.load_seed_hash()
             if self.state.get('password_active'):

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -125,7 +125,7 @@ class ZSR:
         """
         Generate a seed and return its public URL.
         """
-        dev = branch != 'master'
+        dev = branch != 'stable'
 
         if dev:
             latest_version, changed = self.get_latest_version(branch)

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -13,20 +13,13 @@ class ZSR:
     details_endpoint = 'https://ootrandomizer.com/api/v2/seed/details'
     password_endpoint = 'https://ootrandomizer.com/api/v2/seed/pw'
     version_endpoint = 'https://ootrandomizer.com/api/version'
-    settings_endpoints = [
-        'https://raw.githubusercontent.com/OoTRandomizer/OoT-Randomizer/release/data/presets_default.json',
-        'https://raw.githubusercontent.com/OoTRandomizer/OoT-Randomizer/Dev/data/presets_default.json',
-        'https://raw.githubusercontent.com/rrealmuto/OoT-Randomizer/Dev-Rob/data/presets_default.json',
-        'https://raw.githubusercontent.com/fenhl/OoT-Randomizer/dev-fenhl/data/presets_default.json',
-        'https://raw.githubusercontent.com/rrealmuto/OoT-Randomizer/enemy_shuffle/data/presets_default.json'
-    ]
 
     valid_versions = (
-        ('stable', 'Stable (Release)', 'master'),
-        ('dev', 'Dev (Main)', 'dev'),
-        ('dev-rob', 'Dev-Rob', 'devrreal'),
-        ('dev-fenhl', 'Dev-Fenhl', 'devFenhl'),
-        ('dev-enemy-shuffle', 'Dev-Enemy-Shuffle', 'devEnemyShuffle')
+        ('stable', 'Stable (Release)', 'master', 'https://raw.githubusercontent.com/OoTRandomizer/OoT-Randomizer/release/data/presets_default.json'),
+        ('dev', 'Dev (Main)', 'dev', 'https://raw.githubusercontent.com/OoTRandomizer/OoT-Randomizer/Dev/data/presets_default.json'),
+        ('dev-rob', 'Dev-Rob', 'devrreal', 'https://raw.githubusercontent.com/rrealmuto/OoT-Randomizer/Dev-Rob/data/presets_default.json'),
+        ('dev-fenhl', 'Dev-Fenhl', 'devFenhl', 'https://raw.githubusercontent.com/fenhl/OoT-Randomizer/dev-fenhl/data/presets_default.json'),
+        ('dev-enemy-shuffle', 'Dev-Enemy-Shuffle', 'devEnemyShuffle', 'https://raw.githubusercontent.com/rrealmuto/OoT-Randomizer/enemy_shuffle/data/presets_default.json')
     )
 
     hash_map = {
@@ -83,7 +76,7 @@ class ZSR:
                 rtgg_arg = self.valid_versions[i][0],
                 name=self.valid_versions[i][1],
                 ootr_name=self.valid_versions[i][2],
-                settings_endpoint=self.settings_endpoints[i]
+                settings_endpoint=self.valid_versions[i][3]
             )
 
     def roll_seed(self, preset, branch, encrypt, password=False):

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -71,9 +71,9 @@ class ZSR:
         self.build_version_map()
 
     def build_version_map(self):
-        for i, branch in enumerate(self.valid_versions):
-            self.version_map[branch[0]] = Branch(
-                rtgg_arg = self.valid_versions[i][0],
+        for i in range(len(self.valid_versions)):
+            self.version_map[self.valid_versions[i][0]] = Branch(
+                rtgg_arg=self.valid_versions[i][0],
                 name=self.valid_versions[i][1],
                 ootr_name=self.valid_versions[i][2],
                 settings_endpoint=self.valid_versions[i][3]

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -21,9 +21,13 @@ class ZSR:
         'https://raw.githubusercontent.com/rrealmuto/OoT-Randomizer/enemy_shuffle/data/presets_default.json'
     ]
 
-    valid_version_args = ['stable', 'dev', 'dev-rob', 'dev-fenhl', 'dev-enemy-shuffle']
-    version_names = ['Stable (Release)', 'Dev (Main)', 'Dev-Rob', 'Dev-Fenhl', 'Dev-Enemy-Shuffle']
-    ootr_version_names = ['master', 'dev', 'devrreal', 'devFenhl', 'devEnemyShuffle']
+    valid_versions = (
+        ('stable', 'Stable (Release)', 'master'),
+        ('dev', 'Dev (Main)', 'dev'),
+        ('dev-rob', 'Dev-Rob', 'devrreal'),
+        ('dev-fenhl', 'Dev-Fenhl', 'devFenhl'),
+        ('dev-enemy-shuffle', 'Dev-Enemy-Shuffle', 'devEnemyShuffle')
+    )
 
     hash_map = {
         'Beans': 'HashBeans',
@@ -74,11 +78,11 @@ class ZSR:
         self.build_version_map()
 
     def build_version_map(self):
-        for i, rtgg_arg in enumerate(self.valid_version_args):
-            self.version_map[rtgg_arg] = Branch(
-                rtgg_arg = rtgg_arg,
-                name=self.version_names[i],
-                ootr_name=self.ootr_version_names[i],
+        for i, branch in enumerate(self.valid_versions):
+            self.version_map[branch[0]] = Branch(
+                rtgg_arg = self.valid_versions[i][0],
+                name=self.valid_versions[i][1],
+                ootr_name=self.valid_versions[i][2],
                 settings_endpoint=self.settings_endpoints[i]
             )
 
@@ -182,7 +186,7 @@ class Branch:
     
     def get_latest_version(self):
         """
-        Fetch the latest version of the supplied randomzier branch.
+        Fetch the latest version of the supplied randomizer branch.
         """
         version_req = requests.get(ZSR.version_endpoint, params={'branch': self.ootr_name}).json()
         latest_version = version_req['currentlyActiveVersion']


### PR DESCRIPTION
This adds support to roll seeds on the different dev branches available via [OoTRandomizer.com](http://ootrandomizer.com)

Tested to make sure that the different branches do in fact roll seeds though I believe I'm unable to test the password function? Not 100% sure on that

Works as is but I'm thinking it would be cleaner to store the branch data as properties inside instances of a separate class, inside a map within the zsr instance. Let me know

EDIT: Refactored to match what I suggested above, behaves the same