### PR TITLE
Add Default / Beginner preset

### DIFF
--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -170,13 +170,19 @@ class Branch:
         settings = requests.get(self.settings_endpoint).json()
 
         return {
-            min(settings[preset]['aliases'], key=len): {
-                'full_name': preset,
-                'settings': settings.get(preset),
-            }
-            for preset in settings if 'aliases' in settings[preset]
+            'default': {
+                'full_name': 'Default / Beginner',
+                'settings': {},
+            },
+            **{
+                min(settings[preset]['aliases'], key=len): {
+                    'full_name': preset,
+                    'settings': settings.get(preset),
+                }
+                for preset in settings if 'aliases' in settings[preset]
+            },
         }
-    
+
     def get_latest_version(self):
         """
         Fetch the latest version of the supplied randomizer branch.
@@ -184,6 +190,6 @@ class Branch:
         version_req = requests.get(ZSR.version_endpoint, params={'branch': self.ootr_name}).json()
         latest_version = version_req['currentlyActiveVersion']
         return latest_version
-    
+
     def update_version(self, version):
         self.version = version

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -172,7 +172,9 @@ class Branch:
         return {
             'default': {
                 'full_name': 'Default / Beginner',
-                'settings': {},
+                'settings': {
+                    'user_message': 'Default / Beginner',
+                },
             },
             **{
                 min(settings[preset]['aliases'], key=len): {


### PR DESCRIPTION
Adds the “Default / Beginner” preset to all branches for consistency with the randomizer GUI. This preset is automatically generated by selecting the default option for each setting, so we can simply send an empty settings dict to have the randomizer use this preset.

~~Not yet tested.~~ Tested by @jdunn596.