### PR TITLE
Fix Preset Reloading and Dynamically Update When Branches Change

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -206,6 +206,12 @@ class RandoHandler(RaceHandler):
             if args[0] in self.zsr.version_map:
                 self.randomizer_branch = self.zsr.version_map[args[0]]
 
+                if self.randomizer_branch.rtgg_arg != 'stable':
+                    latest_version = self.randomizer_branch.get_latest_version()
+                    if latest_version != self.randomizer_branch.version:
+                        self.randomizer_branch.update_version(latest_version)
+                        self.randomizer_branch.load_presets()
+
                 await self.send_message(
                     f'Randomizer branch changed to: {self.randomizer_branch.name} v{self.randomizer_branch.version}',
                     actions=[

--- a/randobot/zsr.py
+++ b/randobot/zsr.py
@@ -164,15 +164,15 @@ class Branch:
         self.ootr_name = ootr_name
         self.settings_endpoint = settings_endpoint
         self.version = self.get_latest_version()
-        self.presets = self.load_presets()
+        self.load_presets()
 
     def load_presets(self):
         settings = requests.get(self.settings_endpoint).json()
 
-        return {
+        self.presets = {
             min(settings[preset]['aliases'], key=len): {
                 'full_name': preset,
-                'settings': settings.get(preset),
+                'settings': settings.get(preset)
             }
             for preset in settings if 'aliases' in settings[preset]
         }


### PR DESCRIPTION
This fixes a bug where presets wouldn't be fetched when Dev versions were out of date and updated prior to rolling a seed.

This also adds a feature to pull updated data from any Dev branch when switched to, to avoid having to restart the bot to update preset info in the raceroom (such as Standard Weekly (date) prior to rolling a seed).